### PR TITLE
chore: adopt the shared HeroicLands .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,44 @@
 # Dependency directories
-node_modules/
-jspm_packages/
+/node_modules/
 
 # dotenv environment variables file
-.env
-.env.test
+/.env
+/.env.test
+/.env.local
 
-# parcel-bundler cache (https://parceljs.org/)
-.cache
+# AI
+/.claude/
+CLAUDE.md
+AI.md
 
-# Visual Studio
-.vscode/
-*.code-workspace
+# IDE and editor config — per-user; never commit one contributor's editor setup
+# (project-wide policy like Prettier/ESLint config stays tracked; it's not IDE-specific)
+# VS Code (incl. recommended-extensions and settings)
+/.vscode/
+/*.code-workspace
+# JetBrains IDEs (IntelliJ IDEA, WebStorm, etc.) and Fleet
+/.idea/
+/.fleet/
+# Zed
+/.zed/
+# Sublime Text (project + workspace)
+*.sublime-workspace
+*.sublime-project
+# Vim / Neovim
+*.swp
+*.swo
+Session.vim
+.netrwhist
+# Emacs (backups, auto-save, lock files)
+*~
+\#*\#
+.\#*
+
+# Obsidian (assets/content is opened as a vault; local UI state only)
+assets/content/.obsidian/
+
+# GitHub
+.github/copilot-instructions.md
 
 # macOS specific files
 # general
@@ -32,23 +59,26 @@ jspm_packages/
 .com.apple.timemachine.donotpresent
 
 # Build files
-build/
-
-# Distrubution files
-dist/
-
-# Package builds
-package/
-
-# Hidden files
-nogit/
-
-# Foundry Project Creator config file
-foundryconfig.json
-
-# Compiled CSS now lands in the build stage, not the repository.
+/build/
+/coverage/
 /css/
 
-# Foundry writes its compiled LevelDB here when a stage is deployed in place.
-# The compendium source is assets/packs/; this directory is build output only.
-/packs/
+# Cypress run artifacts (specs/support/config are committed)
+/cypress/videos/
+/cypress/screenshots/
+/cypress/downloads/
+
+# Wrangler scratch, from serving the assembled site locally
+# (`npx wrangler pages dev build/site`) to check status codes and 404s.
+/.wrangler/
+
+# Hidden files
+/nogit/
+*.wip
+
+# Generated types package declaration (built via `npm run build:sohl-types`)
+/packages/sohl-types/index.d.ts
+
+# Generated content-build declarations, emitted from the package's JSDoc at
+# pack time (`npm run build:content-build-types`). Sources are the `.mjs`.
+/packages/content-build/types/


### PR DESCRIPTION
## What

Adopts the shared HeroicLands `.gitignore`, taken verbatim from `sohl`, so the
repositories ignore the same things by the same rules rather than each drifting
its own way.

## Why it matters now

- **`/.claude/`** — worktrees live there. Without the rule, `git clean -fd` in
  this checkout deletes them; that was a live hazard while a v14 worktree was
  sitting in one.
- **`/.env.local`** — local Foundry credentials cannot be committed by accident.
  Needed before the end-to-end harness lands, since that is what it reads.
- **Cypress run artifacts** — `videos/`, `screenshots/`, `downloads/` ignored
  while the specs and config stay tracked, again ahead of the harness.
- **Editor state for more than VS Code** — JetBrains, Zed, Sublime, Vim, Emacs.

Paths now anchor to the repository root (`/build/` rather than `build/`), so a
rule cannot match a same-named directory nested somewhere unintended.

## Checked

- No currently-tracked file becomes ignored: `git ls-files -i -c
  --exclude-standard` returns nothing, so nothing silently drops out of version
  control.
- `.env.local` is confirmed untracked and matched by the new rule.

## Worth a second opinion

Three entries are inert in this repository — `/packages/sohl-types/`,
`/packages/content-build/types/`, `/.wrangler/` and the
`assets/content/.obsidian/` vault path have no counterpart here, and two of
their comments name `sohl` npm scripts that do not exist in HM3.

They are kept so the file stays diffable against its source. If these files
should be merely similar rather than identical, say so and I will trim them.
