### PR TITLE
feat(devops): add the end-to-end harness, and fix two regressions it found

### DIFF
--- a/.changeset/e2e-regressions.md
+++ b/.changeset/e2e-regressions.md
@@ -1,0 +1,21 @@
+---
+"hm3": patch
+---
+
+Fixed two regressions from the Foundry v14 release that only showed up once the
+system was driven in a real browser.
+
+**Ability rolls threw.** Both the d6 and d100 ability tests read the list of
+abilities from `game.model`, Foundry's registry of `template.json` defaults.
+Replacing `template.json` with data models left that registry empty, so the
+lookup threw and no ability roll worked at all. The ability names now come from
+the actor.
+
+**Dropdowns forgot their value, and wrote back a number.** Twenty-three
+dropdowns — skill and trait type, weapon aspect, convocation, deity, sunsign,
+armour effective-impact, macro type, and others — render from a plain list of
+strings. Foundry's `selectOptions` helper numbers such a list, producing
+`<option value="0">Craft</option>`, so the stored value never matched and
+nothing appeared selected. Worse, saving the sheet would have written the
+option's *index* into the field. They now render the value they display, as they
+did before v14.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Local configuration for the end-to-end harness. Copy to `.env.local`, which
+# is gitignored — never commit real values.
+#
+# Only the `test` stage matters for the suite; the other stages are the deploy
+# targets `package-build deploy <stage>` writes into.
+
+# Where the disposable Foundry instance keeps its data. This is a *shared*
+# HeroicLands e2e root by design: one Foundry installation holds every system
+# and a world per package, so a single signed licence covers them all.
+#
+# It must not be the same directory as the dev, qa or prod roots — the harness
+# refuses that, because seeding wipes worlds and the image would reuse the wrong
+# licence.
+FOUNDRYVTT_TEST_DATA=/path/to/fvtt/data-e2e
+
+# The world the container launches. Derived from the package id when unset;
+# stated here so it is obvious which of the shared root's worlds this is.
+FOUNDRYVTT_TEST_WORLD=hm3-e2e
+
+# Host port. 30003 is the conventional one for the `test` stage.
+FOUNDRYVTT_TEST_PORT=30003
+
+# Used by the container image to fetch the Foundry release. Not needed once the
+# data root holds a signed Config/license.json.
+FOUNDRY_USERNAME=
+FOUNDRY_PASSWORD=
+
+# A licence key for this stage. Leave unset when the shared data root already
+# carries a signed licence: passing a bare key makes the image write it
+# *unsigned*, and Foundry v13+ refuses to start on an unsigned licence.
+#FOUNDRYVTT_TEST_LICENSE_KEY=

--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -1,0 +1,36 @@
+import { defineConfig } from "cypress";
+import dotenv from "dotenv";
+import { loadPackageBuildConfig } from "@heroiclands/package-build/config";
+import { resolveStagePort } from "@heroiclands/package-build/container";
+import { resolveE2EWorld } from "@heroiclands/package-build/e2e";
+
+dotenv.config({ path: ".env.local", quiet: true });
+dotenv.config({ path: ".env", quiet: true });
+
+// The port and the credentials come from the same resolution the harness seeds
+// with, so `package-build e2e seed` and this file cannot disagree about which
+// world the specs are talking to.
+const buildConfig = loadPackageBuildConfig();
+const port = resolveStagePort(buildConfig.e2eStage, {
+    stages: buildConfig.containerStages,
+});
+const { worldId, gmId, gmName, gmPassword } = resolveE2EWorld(buildConfig);
+
+export default defineConfig({
+    e2e: {
+        baseUrl: `http://localhost:${port}`,
+        supportFile: "cypress/support/e2e.js",
+        specPattern: "cypress/e2e/**/*.cy.js",
+        // Specs log in once and keep the session across their tests. The
+        // default would reload to about:blank between tests, dropping `game`
+        // and the login with it. Isolation between spec *files* still holds.
+        testIsolation: false,
+        // Foundry is a live server driven through a browser; there are no
+        // fixtures to load from disk here, and videos cost more than they say.
+        fixturesFolder: false,
+        video: false,
+        // Everything a spec needs to reach the seeded world, so no spec has to
+        // hard-code a credential.
+        env: { worldId, gmId, gmName, gmPassword },
+    },
+});

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,0 +1,99 @@
+# End-to-end suite
+
+Drives a real Foundry, in a real browser, against a disposable world. It exists
+because the v14 work could otherwise only be argued for: a build passing proves
+nothing about a system that used to die in its `init` hook.
+
+It earned its place on the first run, finding two regressions that had shipped —
+see `fix(v14): repair two regressions the end-to-end suite found`.
+
+## Running it
+
+```bash
+npm run build:noci                  # build the system
+npx package-build deploy test       # install it into the e2e data root
+npm run e2e:seed                    # (re)create the hm3-e2e world
+# start the shared Foundry container — see "One instance, many worlds" below
+npx cypress run                     # or: npx cypress open
+```
+
+## One instance, many worlds
+
+There is **one** e2e Foundry installation, shared by every HeroicLands package.
+Its data root holds each system under `Data/systems/` and a world per package
+under `Data/worlds/`; `FOUNDRY_WORLD` picks which one launches.
+
+This is deliberate, and it is about licensing. Foundry signs a licence to the
+**container hostname**, which Docker takes from the container name:
+
+```
+Config/license.json -> { host: "sohl-foundry-test", …, signature: … }
+```
+
+A container with a different name cannot verify that signature, and an unsigned
+key is refused outright by v13+. One instance therefore means one signed
+licence, rather than one licence consumed per package.
+
+### The wrinkle
+
+`package-build` derives the container name from the package id
+(`containerName(packageId, stage)` → `hm3-foundry-test`) and sets `--hostname`
+to match. That is right for packages with a licence each, and wrong for a shared
+instance: it is the one thing standing between this suite and
+`npm run e2e:full` / `npm run e2e:sweep` working directly.
+
+Until the toolchain can be told the container name, start the shared instance by
+hand and run Cypress against it:
+
+```bash
+docker run --detach \
+  --name sohl-foundry-test --hostname sohl-foundry-test \
+  --publish 30003:30000 \
+  --volume "$FOUNDRYVTT_TEST_DATA:/data" \
+  -e FOUNDRY_WORLD=hm3-e2e \
+  felddy/foundryvtt:14
+```
+
+If it exits immediately with *"already locked by another process"*, remove the
+stale lock — `docker restart` does not clear it the way the toolchain's
+`container recreate` does:
+
+```bash
+rm -rf "$FOUNDRYVTT_TEST_DATA/Config/options.json.lock"
+```
+
+## What is seeded, and what is not
+
+`cypress/fixtures/actors/` holds the four actors from Part 0 of the manual test
+plan — Sir Baris, Mêgan of Geda, a Gârgún Warrior and a Treasure Chest — written
+from the plan's own ability tables so a spec asserting on Endurance can be
+checked against the book.
+
+They carry **no items**. The plan builds their skills and gear by dragging from
+compendiums, and those drags are themselves under test, so baking in the results
+would skip the code the specs exist to exercise.
+
+Each fixture needs a `_key` (`!actors!<id>`). `compilePack` places a record by
+it, and a document without one is skipped in silence.
+
+## Writing specs
+
+- Build document payloads with `cy.createDocument()`. An object literal from the
+  spec's realm is not a plain object to the game window, and Foundry rejects it
+  with *"must be constructed with a DataModel or Object"*.
+- Assert on observables the code cannot undo. The first attempt at the chat-card
+  test watched `button.disabled`, which the handler sets on entry and clears on
+  exit — it read as a listener that never fired, for an hour. `preventDefault()`
+  is the honest signal.
+- `testIsolation` is off, so a spec keeps its login across its tests. Reset world
+  state, not the page; `cy.cleanupByPrefix("E2E ")` removes what a spec made.
+
+## Coverage
+
+Against the manual test plan: Part 0.7 (sheets open), Part 1.1 (each actor
+type), Part 2.4 (editing items), Part 5.1–5.2 and Appendix A (rolls reach chat
+intact), Part 9.1 (active effects).
+
+Not yet covered: automated combat (Parts 6–7), injuries (Part 8), macros
+(Part 10), the gear tab (Part 11), settings (Part 12), edge cases (Part 13) and
+weapon behaviours (Part 14).

--- a/cypress/e2e/chat.cy.js
+++ b/cypress/e2e/chat.cy.js
@@ -1,0 +1,112 @@
+/**
+ * Chat messages carry what they are supposed to carry.
+ *
+ * Three separate v14 schema changes met here, each of which failed silently
+ * rather than loudly:
+ *
+ *  - `roll` became `rolls`, an array. The old key was dropped on the way in, so
+ *    every roll message posted with its roll detached — nothing to expand, and
+ *    nothing for Dice So Nice to animate (issue #389).
+ *  - `user` became `author`. Also dropped, so a message posted on another
+ *    user's behalf lost its attribution.
+ *  - `type` became `style`, and `type` now means the document subtype. The old
+ *    integer was a validation error rather than a silent drop.
+ *
+ * Test plan: Part 5.1/5.2 and Appendix A.
+ */
+describe("chat messages", () => {
+    before(() => cy.login());
+
+    /** Post a d100 test through the system's own dice layer. */
+    const rollAbility = (actorName, ability) =>
+        cy.hm3Actor(actorName).then((actor) =>
+            cy.window().then((win) =>
+                win.game.hm3.macros.testAbilityD100Roll(ability, true, actor)
+            )
+        );
+
+    /** The most recently posted chat message. */
+    const latest = () => cy.window().then((win) => win.game.messages.contents.at(-1));
+
+    beforeEach(() => cy.window().then((win) => win.game.messages.documentClass.deleteDocuments(
+        win.game.messages.map((m) => m.id)
+    )));
+
+    it("posts an ability roll", () => {
+        rollAbility("Sir Baris", "strength");
+        latest().should("exist");
+    });
+
+    it("keeps the roll attached to the message", () => {
+        // The regression behind #389: `messageData.roll` was silently discarded,
+        // so `rolls` came out empty and there was no dice animation.
+        rollAbility("Sir Baris", "strength");
+        latest().then((msg) => {
+            expect(msg.rolls, "message.rolls").to.have.length.of.at.least(1);
+            expect(msg.rolls[0].total, "roll total").to.be.a("number");
+            expect(msg.isRoll, "message.isRoll").to.be.true;
+        });
+    });
+
+    it("attributes the message to the acting user", () => {
+        rollAbility("Sir Baris", "strength");
+        cy.window().then((win) => {
+            latest().then((msg) => {
+                expect(msg.author?.id, "message author").to.equal(win.game.user.id);
+            });
+        });
+    });
+
+    it("sets a valid style, and leaves type as the document subtype", () => {
+        rollAbility("Sir Baris", "strength");
+        cy.window().then((win) => {
+            latest().then((msg) => {
+                expect(Object.values(win.CONST.CHAT_MESSAGE_STYLES)).to.include(msg.style);
+                // `type` is a DocumentTypeField now; an integer here would have
+                // failed validation outright.
+                expect(msg.type).to.be.a("string");
+            });
+        });
+    });
+
+    it("renders the message into the log", () => {
+        rollAbility("Sir Baris", "strength");
+        latest().then((msg) => {
+            cy.get(`.chat-message[data-message-id="${msg.id}"]`, { timeout: 10000 })
+                .should("exist");
+        });
+    });
+
+    it("wires up chat card action buttons", () => {
+        // `chatListeners` bound with jQuery's `html.on(...)`, but the chat log
+        // has handed over an HTMLElement since v13 — so this threw and every
+        // card button on every message went dead. The listener is delegated
+        // from the log root now.
+        cy.createDocument("ChatMessage", {
+            content: `<div class="hm3 chat-card">
+                <div class="card-buttons">
+                    <button data-action="e2e-probe">Probe</button>
+                </div>
+            </div>`,
+        });
+        cy.get(".card-buttons button[data-action='e2e-probe']", { timeout: 10000 })
+            .should("exist");
+        cy.window().then((win) => {
+            const button = win.document.querySelector(
+                ".card-buttons button[data-action='e2e-probe']"
+            );
+            expect(button, "probe button").to.exist;
+
+            // `_onChatCardAction` calls preventDefault() as soon as it matches a
+            // card button, and nothing undoes that — unlike `disabled`, which it
+            // sets on entry and clears again before returning.
+            const event = new win.MouseEvent("click", { bubbles: true, cancelable: true });
+            button.dispatchEvent(event);
+            expect(event.defaultPrevented, "HM3's delegated handler ran").to.be.true;
+        });
+    });
+
+    after(() => cy.window().then((win) =>
+        win.game.messages.documentClass.deleteDocuments(win.game.messages.map((m) => m.id))
+    ));
+});

--- a/cypress/e2e/dropdowns-and-effects.cy.js
+++ b/cypress/e2e/dropdowns-and-effects.cy.js
@@ -1,0 +1,138 @@
+/**
+ * Dropdowns render with a selection, and active effects can be created.
+ *
+ * Two more things the v14 work could only be reasoned about:
+ *
+ *  - `{{#select}}` was removed in v14. All 35 blocks were rewritten, 22 onto
+ *    `{{selectOptions}}` and 13 onto an explicit `selected` attribute. A
+ *    mistake in either shows up as a dropdown that renders but forgets its
+ *    value.
+ *  - ActiveEffect renamed `label`/`icon` to `name`/`img` in v11, with no
+ *    migration left in v14 and `name` required and non-blank — so creating an
+ *    effect failed validation outright.
+ *
+ * Test plan: Part 2.4 (editing items), Part 9.1 (create and apply effects).
+ */
+describe("dropdowns", () => {
+    before(() => cy.login());
+    afterEach(() => cy.closeAllSheets());
+    after(() => cy.cleanupByPrefix("E2E "));
+
+    /**
+     * Open an item's sheet and return its select elements.
+     *
+     * @param {string} type - Item subtype.
+     * @param {object} system - System data to set.
+     */
+    const withItemSheet = (type, system = {}) =>
+        cy.createDocument("Item", { name: `E2E ${type} dropdown`, type, system }).then((item) =>
+            cy.window().then(async () => {
+                await item.sheet.render(true);
+                return item;
+            })
+        );
+
+    it("renders a skill's type dropdown with the stored value selected", () => {
+        withItemSheet("skill", { type: "Combat" }).then((item) => {
+            const select = item.sheet.element.querySelector('select[name="system.type"]');
+            expect(select, "type select").to.exist;
+            expect(select.options.length, "has options").to.be.greaterThan(1);
+            expect(select.value, "keeps its stored value").to.equal("Combat");
+        });
+    });
+
+    it("renders a trait's type dropdown with the stored value selected", () => {
+        withItemSheet("trait", { type: "Psyche" }).then((item) => {
+            const select = item.sheet.element.querySelector('select[name="system.type"]');
+            expect(select.value).to.equal("Psyche");
+        });
+    });
+
+    it("renders the missile weapon aspect dropdown from the config list", () => {
+        // This one stopped being a hand-maintained copy of three <option> tags
+        // and became `HM3.allowedAspects`.
+        withItemSheet("missilegear", { weaponAspect: "Blunt" }).then((item) => {
+            const select = item.sheet.element.querySelector('select[name="system.weaponAspect"]');
+            expect(select.value).to.equal("Blunt");
+            const values = [...select.options].map((o) => o.value);
+            expect(values).to.have.members(["Edged", "Piercing", "Blunt"]);
+        });
+    });
+
+    it("renders armour location effective-impact dropdowns", () => {
+        // Five `{{#select}}` blocks in one template, all converted at once.
+        withItemSheet("armorlocation", {}).then((item) => {
+            const el = item.sheet.element;
+            for (const [field, expected] of Object.entries({
+                ei1: "M1", ei5: "S2", ei9: "S3", ei13: "G4", ei17: "G5",
+            })) {
+                const select = el.querySelector(`select[name="system.effectiveImpact.${field}"]`);
+                expect(select, `${field} select`).to.exist;
+                expect(select.value, `${field} default`).to.equal(expected);
+            }
+        });
+    });
+
+    it("keeps a changed dropdown value after the sheet re-renders", () => {
+        withItemSheet("skill", { type: "Craft" }).then((item) => {
+            return cy.window().then(async (win) => {
+                await item.update(win.JSON.parse(JSON.stringify({ "system.type": "Physical" })));
+                await item.sheet.render(true);
+                const select = item.sheet.element.querySelector('select[name="system.type"]');
+                expect(select.value).to.equal("Physical");
+            });
+        });
+    });
+});
+
+describe("active effects", () => {
+    before(() => cy.login());
+    afterEach(() => cy.closeAllSheets());
+    after(() => cy.cleanupByPrefix("E2E "));
+
+    it("creates an effect on an actor", () => {
+        // `label`/`icon` would fail validation here: `name` is required and may
+        // not be blank, and v14 keeps no migration from the old keys.
+        cy.hm3Actor("Sir Baris").then((actor) =>
+            cy.createDocument(
+                "ActiveEffect",
+                { name: "E2E Test Effect", img: "icons/svg/aura.svg", origin: actor.uuid },
+                { parent: actor }
+            ).then((effect) => {
+                expect(effect, "created effect").to.exist;
+                expect(effect.name).to.equal("E2E Test Effect");
+                return cy.window().then(() => effect.delete());
+            })
+        );
+    });
+
+    it("opens the HM3 effect config, offering the system's key list", () => {
+        cy.hm3Actor("Sir Baris").then((actor) =>
+            cy.createDocument(
+                "ActiveEffect",
+                {
+                    name: "E2E Keyed Effect",
+                    img: "icons/svg/aura.svg",
+                    changes: [{ key: "system.eph.meleeAMLMod", mode: 2, value: "10" }],
+                },
+                { parent: actor }
+            ).then((effect) => cy.window().then(async () => {
+                expect(effect.sheet.constructor.name, "HM3's config, not core's")
+                    .to.equal("HM3ActiveEffectConfig");
+                await effect.sheet.render(true);
+                return { effect, sheet: effect.sheet };
+            })).then(({ effect, sheet }) => {
+                // The curated key list is supplied by giving the schema field
+                // its `choices`, so core's own template renders a <select>.
+                const select = sheet.element.querySelector('select[name*="changes.0.key"]');
+                expect(select, "key rendered as a dropdown").to.exist;
+                const values = [...select.options].map((o) => o.value);
+                expect(values).to.include("system.eph.meleeAMLMod");
+                return cy.window().then(async () => {
+                    await sheet.close();
+                    await effect.delete();
+                });
+            })
+        );
+    });
+});

--- a/cypress/e2e/sheets.cy.js
+++ b/cypress/e2e/sheets.cy.js
@@ -1,0 +1,111 @@
+/**
+ * The sheets render and their tabs work, on ApplicationV2.
+ *
+ * Covers what the v14 conversion could only be reasoned about statically:
+ * the sheets are now ApplicationV2, their templates lost the `<form>` wrapper
+ * they used to be built around, `.window-content` sits between the form and the
+ * sheet body where nothing sat before, and tab switching runs through AppV2's
+ * `data-action="tab"` dispatcher rather than AppV1's tab controller.
+ *
+ * Test plan: Part 1.1 (each actor type opens), Part 0.7 (sheets open without
+ * errors).
+ */
+describe("sheets", () => {
+    before(() => cy.login());
+    afterEach(() => cy.closeAllSheets());
+
+    const cases = [
+        { name: "Sir Baris", type: "character", tabs: ["facade", "profile", "skills", "combat", "esoteric", "inventory", "macro", "effects"] },
+        { name: "Gârgún Warrior", type: "creature", tabs: ["facade", "profile", "skills", "combat", "esoteric", "inventory", "macro", "effects"] },
+        { name: "Treasure Chest", type: "container", tabs: ["facade"] },
+    ];
+
+    for (const { name, type, tabs } of cases) {
+        describe(`${type}: ${name}`, () => {
+            it("opens as an ApplicationV2 sheet", () => {
+                cy.openActorSheet(name);
+                cy.hm3Actor(name).then((actor) => {
+                    const sheet = actor.sheet;
+                    // ApplicationV2, not the AppV1 class it used to extend.
+                    expect(sheet).to.be.instanceOf(
+                        cy.state("window").foundry.applications.api.ApplicationV2
+                    );
+                    // DocumentSheetV2 renders itself as the form.
+                    expect(sheet.element.tagName.toLowerCase()).to.equal("form");
+                    expect(sheet.element.classList.contains("hm3")).to.be.true;
+                });
+            });
+
+            it("renders its header and body inside the window content", () => {
+                cy.openActorSheet(name);
+                cy.hm3Actor(name).then((actor) => {
+                    const el = actor.sheet.element;
+                    expect(el.querySelector(".window-content"), ".window-content").to.exist;
+                    expect(el.querySelector(".sheet-header"), ".sheet-header").to.exist;
+                });
+            });
+
+            it("shows exactly one active tab, and switches between them", () => {
+                cy.openActorSheet(name);
+                cy.hm3Actor(name).then((actor) => {
+                    const el = actor.sheet.element;
+                    const active = el.querySelectorAll('.tab[data-group="primary"].active');
+                    expect(active.length, "one active tab on first render").to.equal(1);
+                });
+
+                if (tabs.length < 2) return;
+
+                // Click each nav entry and confirm the matching content becomes
+                // the active one. AppV2's changeTab drives this off
+                // data-action="tab", which the templates gained in the
+                // conversion — before it, nothing was listening.
+                for (const tab of tabs) {
+                    cy.hm3Actor(name).then((actor) => {
+                        const el = actor.sheet.element;
+                        const nav = el.querySelector(`nav .item[data-tab="${tab}"]`);
+                        if (!nav) return; // this type does not carry that tab
+                        nav.click();
+                        const content = el.querySelector(`.tab[data-tab="${tab}"]`);
+                        expect(content?.classList.contains("active"), `${tab} became active`).to.be.true;
+                        expect(
+                            el.querySelectorAll('.tab[data-group="primary"].active').length,
+                            `only ${tab} is active`
+                        ).to.equal(1);
+                    });
+                }
+            });
+        });
+    }
+
+    it("opens an item sheet for every item type", () => {
+        // One sheet class serves all twelve types, choosing its template in
+        // _configureRenderParts — the AppV2 replacement for AppV1's dynamic
+        // `get template()`. A type whose template failed to resolve would throw
+        // here rather than silently render blank.
+        const types = [
+            "skill", "spell", "invocation", "psionic", "weapongear",
+            "containergear", "missilegear", "armorgear", "miscgear",
+            "injury", "armorlocation", "trait",
+        ];
+        cy.window().then(async (win) => {
+            for (const type of types) {
+                // Rebuilt in the window's realm; a literal from the spec's
+                // realm fails Foundry's plain-object check.
+                const item = await win.Item.implementation.create(
+                    win.JSON.parse(JSON.stringify({ name: `E2E ${type}`, type }))
+                );
+                expect(item, `created ${type}`).to.exist;
+                await item.sheet.render(true);
+                expect(item.sheet.element, `${type} sheet element`).to.exist;
+                expect(
+                    item.sheet.element.querySelector(".sheet-header"),
+                    `${type} sheet header`
+                ).to.exist;
+                await item.sheet.close();
+                await item.delete();
+            }
+        });
+    });
+
+    after(() => cy.cleanupByPrefix("E2E "));
+});

--- a/cypress/e2e/system-loads.cy.js
+++ b/cypress/e2e/system-loads.cy.js
@@ -1,0 +1,96 @@
+/**
+ * The system initialises on Foundry v14.
+ *
+ * This is the spec the whole harness exists for. Before the v14 work, HM3's
+ * `init` hook read `CONFIG.TinyMCE` — removed in v14 along with the editor — so
+ * the hook threw on that line and *nothing after it ran*: no document classes,
+ * no sheet registration, no settings. The system did not load at all.
+ *
+ * Everything here asserts on state that only exists if `init` ran to
+ * completion, so a regression that breaks the hook fails these rather than
+ * failing mysteriously somewhere later.
+ */
+describe("system initialisation", () => {
+    before(() => cy.login());
+
+    it("is the active system, at the expected generation", () => {
+        cy.window().then((win) => {
+            expect(win.game.system.id).to.equal("hm3");
+            expect(Number(win.game.release.generation)).to.be.at.least(14);
+        });
+    });
+
+    it("ran init to completion", () => {
+        cy.window().then((win) => {
+            // Assigned at the very end of the init hook, after the document
+            // classes, the sheets and the fonts. If this is here, the whole
+            // hook ran.
+            expect(win.CONFIG.fontDefinitions).to.have.property("Lankorian Blackhand");
+            expect(win.CONFIG.HM3, "CONFIG.HM3").to.exist;
+            expect(win.game.hm3, "game.hm3 API").to.have.keys(
+                "HarnMasterActor", "HarnMasterItem", "DiceHM3", "config", "macros", "migrations"
+            );
+        });
+    });
+
+    it("registered the custom document classes", () => {
+        cy.window().then((win) => {
+            expect(win.CONFIG.Actor.documentClass.name).to.equal("HarnMasterActor");
+            expect(win.CONFIG.Item.documentClass.name).to.equal("HarnMasterItem");
+            expect(win.CONFIG.Combat.documentClass.name).to.equal("HarnMasterCombat");
+        });
+    });
+
+    it("registered a data model for every declared subtype", () => {
+        cy.window().then((win) => {
+            // template.json is gone; these are what replaced it. A subtype
+            // declared in the manifest with no model would fall back to an
+            // untyped blob and lose its defaults silently.
+            const actorTypes = ["character", "creature", "container"];
+            const itemTypes = [
+                "skill", "spell", "invocation", "psionic", "weapongear",
+                "containergear", "missilegear", "armorgear", "miscgear",
+                "injury", "armorlocation", "trait",
+            ];
+            expect(Object.keys(win.CONFIG.Actor.dataModels)).to.have.members(actorTypes);
+            expect(Object.keys(win.CONFIG.Item.dataModels)).to.have.members(itemTypes);
+        });
+    });
+
+    it("has no TinyMCE configuration left to read", () => {
+        // The exact thing that killed init. ProseMirror replaced it, and the
+        // Highlight block moved to CONFIG.TextEditor.inserts.
+        cy.window().then((win) => {
+            expect(win.CONFIG.TinyMCE, "CONFIG.TinyMCE").to.be.undefined;
+            const actions = win.CONFIG.TextEditor.inserts.map((i) => i.action);
+            expect(actions).to.include("highlight");
+        });
+    });
+
+    it("offers the Harnic fonts to the ProseMirror editor", () => {
+        cy.window().then((win) => {
+            const available = win.foundry.applications.settings.menus.FontConfig.getAvailableFonts();
+            expect(available).to.include.members(["Lakise", "Runic", "Lankorian Blackhand"]);
+        });
+    });
+
+    it("seeded the four test actors, each with a typed data model", () => {
+        cy.window().then((win) => {
+            for (const name of ["Sir Baris", "Mêgan of Geda", "Gârgún Warrior", "Treasure Chest"]) {
+                const actor = win.game.actors.getName(name);
+                expect(actor, name).to.exist;
+                // A DataModel instance, not the plain object template.json gave.
+                expect(actor.system, `${name} system`).to.be.instanceOf(win.foundry.abstract.DataModel);
+            }
+        });
+    });
+
+    it("computed derived data for a character", () => {
+        // Endurance is (STR + STA + WIL) / 3, rounded. Sir Baris is 15/14/14.
+        cy.hm3Actor("Sir Baris").then((actor) => {
+            expect(actor.system.abilities.strength.base).to.equal(15);
+            expect(actor.system.endurance).to.equal(Math.round((15 + 14 + 14) / 3));
+            expect(actor.system.universalPenalty).to.equal(0);
+        });
+    });
+});

--- a/cypress/fixtures/actors/G_rg_n_Warrior_hm3e2eGargunWar1.json
+++ b/cypress/fixtures/actors/G_rg_n_Warrior_hm3e2eGargunWar1.json
@@ -1,0 +1,86 @@
+{
+  "_id": "hm3e2eGargunWar1",
+  "name": "Gârgún Warrior",
+  "type": "creature",
+  "system": {
+    "bioImage": "systems/hm3/images/svg/knight-silhouette.svg",
+    "species": "Gârgún",
+    "fatigue": 0,
+    "sunsign": "",
+    "move": {
+      "base": 0
+    },
+    "shockIndex": {
+      "max": 100,
+      "value": 100
+    },
+    "description": "",
+    "biography": "",
+    "macros": {
+      "type": "script",
+      "command": ""
+    },
+    "abilities": {
+      "strength": {
+        "base": 14
+      },
+      "stamina": {
+        "base": 16
+      },
+      "dexterity": {
+        "base": 10
+      },
+      "agility": {
+        "base": 11
+      },
+      "intelligence": {
+        "base": 5
+      },
+      "aura": {
+        "base": 4
+      },
+      "will": {
+        "base": 10
+      },
+      "eyesight": {
+        "base": 10
+      },
+      "hearing": {
+        "base": 12
+      },
+      "smell": {
+        "base": 14
+      },
+      "voice": {
+        "base": 6
+      },
+      "comeliness": {
+        "base": 3
+      },
+      "morality": {
+        "base": 6
+      }
+    },
+    "loadRating": 20
+  },
+  "_key": "!actors!hm3e2eGargunWar1",
+  "img": "systems/hm3/images/svg/knight-silhouette.svg",
+  "items": [],
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "prototypeToken": {
+    "name": "Gârgún Warrior",
+    "displayName": 20,
+    "actorLink": true,
+    "width": 1,
+    "height": 1,
+    "texture": {
+      "src": "systems/hm3/images/svg/knight-silhouette.svg"
+    }
+  }
+}

--- a/cypress/fixtures/actors/M_gan_of_Geda_hm3e2eMeganGeda1.json
+++ b/cypress/fixtures/actors/M_gan_of_Geda_hm3e2eMeganGeda1.json
@@ -1,0 +1,87 @@
+{
+  "_id": "hm3e2eMeganGeda1",
+  "name": "Mêgan of Geda",
+  "type": "character",
+  "system": {
+    "bioImage": "systems/hm3/images/svg/knight-silhouette.svg",
+    "species": "Human",
+    "fatigue": 0,
+    "sunsign": "Tai",
+    "move": {
+      "base": 0
+    },
+    "shockIndex": {
+      "max": 100,
+      "value": 100
+    },
+    "description": "",
+    "biography": "",
+    "macros": {
+      "type": "script",
+      "command": ""
+    },
+    "abilities": {
+      "strength": {
+        "base": 9
+      },
+      "stamina": {
+        "base": 10
+      },
+      "dexterity": {
+        "base": 14
+      },
+      "agility": {
+        "base": 13
+      },
+      "intelligence": {
+        "base": 15
+      },
+      "aura": {
+        "base": 16
+      },
+      "will": {
+        "base": 12
+      },
+      "eyesight": {
+        "base": 14
+      },
+      "hearing": {
+        "base": 11
+      },
+      "smell": {
+        "base": 10
+      },
+      "voice": {
+        "base": 13
+      },
+      "comeliness": {
+        "base": 14
+      },
+      "morality": {
+        "base": 11
+      }
+    },
+    "gender": "Female",
+    "occupation": "Shek-Pvar"
+  },
+  "_key": "!actors!hm3e2eMeganGeda1",
+  "img": "systems/hm3/images/svg/knight-silhouette.svg",
+  "items": [],
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "prototypeToken": {
+    "name": "Mêgan of Geda",
+    "displayName": 20,
+    "actorLink": true,
+    "width": 1,
+    "height": 1,
+    "texture": {
+      "src": "systems/hm3/images/svg/knight-silhouette.svg"
+    }
+  }
+}

--- a/cypress/fixtures/actors/Sir_Baris_hm3e2eSirBaris01.json
+++ b/cypress/fixtures/actors/Sir_Baris_hm3e2eSirBaris01.json
@@ -1,0 +1,87 @@
+{
+  "_id": "hm3e2eSirBaris01",
+  "name": "Sir Baris",
+  "type": "character",
+  "system": {
+    "bioImage": "systems/hm3/images/svg/knight-silhouette.svg",
+    "species": "Human",
+    "fatigue": 0,
+    "sunsign": "Ahnu",
+    "move": {
+      "base": 0
+    },
+    "shockIndex": {
+      "max": 100,
+      "value": 100
+    },
+    "description": "",
+    "biography": "",
+    "macros": {
+      "type": "script",
+      "command": ""
+    },
+    "abilities": {
+      "strength": {
+        "base": 15
+      },
+      "stamina": {
+        "base": 14
+      },
+      "dexterity": {
+        "base": 13
+      },
+      "agility": {
+        "base": 12
+      },
+      "intelligence": {
+        "base": 10
+      },
+      "aura": {
+        "base": 9
+      },
+      "will": {
+        "base": 14
+      },
+      "eyesight": {
+        "base": 11
+      },
+      "hearing": {
+        "base": 10
+      },
+      "smell": {
+        "base": 8
+      },
+      "voice": {
+        "base": 10
+      },
+      "comeliness": {
+        "base": 12
+      },
+      "morality": {
+        "base": 12
+      }
+    },
+    "gender": "Male",
+    "occupation": "Knight"
+  },
+  "_key": "!actors!hm3e2eSirBaris01",
+  "img": "systems/hm3/images/svg/knight-silhouette.svg",
+  "items": [],
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "prototypeToken": {
+    "name": "Sir Baris",
+    "displayName": 20,
+    "actorLink": true,
+    "width": 1,
+    "height": 1,
+    "texture": {
+      "src": "systems/hm3/images/svg/knight-silhouette.svg"
+    }
+  }
+}

--- a/cypress/fixtures/actors/Treasure_Chest_hm3e2eTreasChest.json
+++ b/cypress/fixtures/actors/Treasure_Chest_hm3e2eTreasChest.json
@@ -1,0 +1,33 @@
+{
+  "_id": "hm3e2eTreasChest",
+  "name": "Treasure Chest",
+  "type": "container",
+  "system": {
+    "bioImage": "systems/hm3/images/icons/svg/chest.svg",
+    "description": "",
+    "macros": {},
+    "capacity": {
+      "max": 100
+    }
+  },
+  "_key": "!actors!hm3e2eTreasChest",
+  "img": "systems/hm3/images/icons/svg/chest.svg",
+  "items": [],
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "prototypeToken": {
+    "name": "Treasure Chest",
+    "displayName": 20,
+    "actorLink": true,
+    "width": 1,
+    "height": 1,
+    "texture": {
+      "src": "systems/hm3/images/icons/svg/chest.svg"
+    }
+  }
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,108 @@
+/**
+ * Log in to the seeded world and wait until the game client is ready.
+ *
+ * Authenticates against Foundry's `/join` endpoint — the same POST the join
+ * screen makes — with the seeded Gamemaster, then loads `/game` and waits for
+ * `game.ready`. Credentials come from `Cypress.env`, populated by
+ * `cypress.config.mjs` from the same resolution the seed used, so a spec only
+ * ever calls `cy.login()`.
+ */
+Cypress.Commands.add("login", (opts = {}) => {
+    const userId = opts.userId ?? Cypress.env("gmId");
+    const password = opts.password ?? Cypress.env("gmPassword");
+
+    cy.request({
+        method: "POST",
+        url: "/join",
+        // Foundry renamed this body field from `userid` to `userId` in 14.367;
+        // `sessions.authenticateUser` destructures one or the other depending
+        // on the build. Sending both spans the whole supported range — the
+        // handler takes the name it wants and ignores the other.
+        body: { action: "join", userid: userId, userId, password },
+    }).then((res) => {
+        // A successful join answers JSON. When the world is not active Foundry
+        // answers 200 with an HTML error page, so assert on the payload rather
+        // than the status code.
+        expect(res.body, "join response").to.have.property("status", "success");
+    });
+
+    cy.visit("/game");
+    cy.window({ timeout: 60000 }).its("game").its("ready").should("eq", true);
+});
+
+/**
+ * The seeded actor of a given name, as a live document.
+ *
+ * @param {string} name - The actor's name.
+ */
+Cypress.Commands.add("hm3Actor", (name) =>
+    cy.window().then((win) => {
+        const actor = win.game.actors.getName(name);
+        expect(actor, `actor "${name}" exists in the seeded world`).to.exist;
+        return actor;
+    })
+);
+
+/**
+ * Open an actor's sheet and wait for it to be on screen.
+ *
+ * Waits on the rendered element rather than on `render()` resolving:
+ * ApplicationV2 resolves its render promise before the parts are attached, and
+ * asserting too early is the most common way one of these specs goes flaky.
+ *
+ * @param {string} name - The actor's name.
+ */
+Cypress.Commands.add("openActorSheet", (name) => {
+    cy.hm3Actor(name).then((actor) => {
+        actor.sheet.render(true);
+        return cy.get(`#${CSS.escape(actor.sheet.id)}`, { timeout: 20000 }).should("be.visible");
+    });
+});
+
+/**
+ * Close every open application, so one spec's windows cannot confuse the next.
+ */
+Cypress.Commands.add("closeAllSheets", () =>
+    cy.window().then((win) => {
+        for (const app of Object.values(win.ui.windows ?? {})) app.close?.();
+        for (const app of win.foundry.applications.instances?.values?.() ?? []) {
+            if (app.constructor.name !== "ChatLog") app.close?.();
+        }
+    })
+);
+
+/**
+ * Delete every document created during a spec, identified by a name prefix.
+ *
+ * `testIsolation` is off so the page persists across a spec's tests; world
+ * state is what has to be reset, and only what the spec made.
+ *
+ * @param {string} prefix - Name prefix marking a document as the spec's.
+ */
+Cypress.Commands.add("cleanupByPrefix", (prefix) =>
+    cy.window().then(async (win) => {
+        for (const collection of [win.game.actors, win.game.items]) {
+            const ids = collection.filter((d) => d.name.startsWith(prefix)).map((d) => d.id);
+            if (ids.length) await collection.documentClass.deleteDocuments(ids);
+        }
+    })
+);
+
+/**
+ * Create a document from the application's own realm.
+ *
+ * An object literal built in the spec's realm is not a plain object as far as
+ * the game window is concerned — Foundry's constructor check rejects it with
+ * "must be constructed with a DataModel or Object". Round-tripping the payload
+ * through the window's own JSON rebuilds it on the right side of the boundary.
+ *
+ * @param {string} documentName - e.g. "Item", "ChatMessage".
+ * @param {object} data - The document data.
+ * @param {object} [options] - Creation options; may carry a live `parent`.
+ */
+Cypress.Commands.add("createDocument", (documentName, data, options = {}) =>
+    cy.window().then((win) => {
+        const cls = win.CONFIG[documentName].documentClass;
+        return cls.create(win.JSON.parse(JSON.stringify(data)), options);
+    })
+);

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,25 @@
+// Loaded before every spec.
+import "./commands.js";
+
+/**
+ * Ignore async exceptions thrown by Foundry's own canvas rendering in the
+ * headless browser, which has no real viewport.
+ *
+ * Kept to an explicit allowlist of message fragments so that any *other*
+ * uncaught error still fails the spec — the point of this suite is to catch
+ * errors the v14 work might have introduced, and a blanket
+ * `return false` would hide exactly those.
+ *
+ * @type {string[]}
+ */
+const IGNORED = [
+    // The token layer and its render flags are absent without a viewport;
+    // placing or moving a token throws out of a PIXI ticker callback.
+    "Cannot read properties of undefined (reading 'OBJECTS')",
+    "Cannot read properties of null (reading 'addChild')",
+];
+
+Cypress.on("uncaught:exception", (err) => {
+    if (IGNORED.some((fragment) => err.message.includes(fragment))) return false;
+    return true;
+});

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -177,7 +177,8 @@ export class HarnMasterActor extends Actor {
      * @returns an armorlocation ItemData
      */
     static _setupLocation(locName, templateName) {
-        const armorLocationData = foundry.utils.deepClone(game.model.Item.armorlocation);
+        // The schema's defaults, which is what `game.model` used to hold.
+        const armorLocationData = CONFIG.Item.dataModels.armorlocation.schema.getInitialValue({});
         foundry.utils.mergeObject(armorLocationData, HM3.injuryLocations[templateName])
         return { name: locName, type: 'armorlocation', system: armorLocationData };
     }

--- a/module/hm3.js
+++ b/module/hm3.js
@@ -141,6 +141,16 @@ Hooks.once('init', async function () {
         return str.toLowerCase();
     });
 
+    // `selectOptions` reads an array entry that is not an object as
+    // `{value: index, label: entry}`, so a plain list of strings renders
+    // `<option value="0">Craft</option>` and the stored value never matches.
+    // Reading it as an object gives value === label, which is what the
+    // `{{#select}}` blocks these replaced always produced.
+    Handlebars.registerHelper('toChoices', function (list) {
+        if (Array.isArray(list)) return Object.fromEntries(list.map(v => [v, v]));
+        return list ?? {};
+    });
+
     // Register the Harnic fonts with Foundry. `editor: true` is what puts a
     // family in the ProseMirror font menu: FontConfig.getAvailableFonts()
     // collects exactly the families whose definition sets it, and the editor

--- a/module/macros.js
+++ b/module/macros.js
@@ -345,15 +345,14 @@ export async function testAbilityD6Roll(ability, noDialog = false, myActor=null)
         return null;
     }
 
-    let abilities;
-    if (actorInfo.actor.type === 'character') {
-        abilities = Object.keys(game.model.Actor.character.abilities);
-    } else if (actorInfo.actor.type === 'creature') {
-        abilities = Object.keys(game.model.Actor.creature.abilities);
-    } else {
+    // Read the ability names off the actor itself. They used to come from
+    // `game.model`, the template.json registry, which is empty now that the
+    // system declares data models instead.
+    if (!actorInfo.actor.system.abilities) {
         ui.notifications.warn(`${actorInfo.name} does not have ability scores.`);
         return null;
     }
+    const abilities = Object.keys(actorInfo.actor.system.abilities);
     if (!ability || !abilities.includes(ability)) return null;
 
 
@@ -392,15 +391,14 @@ export async function testAbilityD100Roll(ability, noDialog = false, myActor = n
         return null;
     }
 
-    let abilities;
-    if (actorInfo.actor.type === 'character') {
-        abilities = Object.keys(game.model.Actor.character.abilities);
-    } else if (actorInfo.actor.type === 'creature') {
-        abilities = Object.keys(game.model.Actor.creature.abilities);
-    } else {
+    // Read the ability names off the actor itself. They used to come from
+    // `game.model`, the template.json registry, which is empty now that the
+    // system declares data models instead.
+    if (!actorInfo.actor.system.abilities) {
         ui.notifications.warn(`${actorInfo.actor.name} does not have ability scores.`);
         return null;
     }
+    const abilities = Object.keys(actorInfo.actor.system.abilities);
     if (!ability || !abilities.includes(ability)) return null;
 
     const stdRollData = {

--- a/module/migrations.js
+++ b/module/migrations.js
@@ -300,9 +300,10 @@ export const migrateActorData = function (actor) {
  */
 function cleanActorData(actorData) {
 
-  // Scrub system data
-  const model = game.model.Actor[actorData.type];
-  actorData.system = filterObject(actorData.system, model);
+  // Scrub system data against the type's schema. This was `game.model`, the
+  // template.json registry, which no longer carries the fields.
+  const model = CONFIG.Actor.dataModels[actorData.type]?.schema.getInitialValue({});
+  if (model) actorData.system = filterObject(actorData.system, model);
 
   // Scrub system flags
   const allowedFlags = CONFIG.HM3.allowedActorFlags.reduce((obj, f) => {

--- a/package-build.config.yaml
+++ b/package-build.config.yaml
@@ -62,6 +62,39 @@ packageBuild:
     deploy:
         envPrefix: HM3
 
+    # The end-to-end harness: a disposable Foundry world, seeded from scratch,
+    # with Cypress driving a real browser against it.
+    #
+    # Almost nothing is stated here because almost nothing is this repository's
+    # to state. The world id and the Gamemaster derive from the package id
+    # (`hm3-e2e`, `Gamemaster` / `hm3-e2e`), the port is the conventional one
+    # for the `test` stage, and the Foundry build is `compatibility.minimum`
+    # above — the floor is the claim the suite exists to defend, so the claim
+    # and the evidence for it are one number. `npm run e2e:sweep -- <build>`
+    # runs the full suite against a build this repository does not pin.
+    e2e:
+        # The one thing the harness does not own: what runs against the world.
+        suite:
+            run: [npx, cypress, run]
+            open: [npx, cypress, open]
+
+        # What the fast loop can rebuild, in the order it must be built. The
+        # asset pass empties the stage, so it goes first; `system` writes the
+        # manifest, which Foundry reads once at world launch, so producing it
+        # means the container is recreated rather than merely restarted.
+        build:
+            assets: build:assets
+            css: build:css
+            db: build:compiledb
+            system: { script: build:system, recreate: true }
+
+        # The actors from Part 0 of the manual test plan, compiled into the
+        # seeded world so every spec starts from the same known state. Their
+        # gear and skills are not seeded: adding those is what the drag-and-drop
+        # specs exercise, and baking them in would skip the code under test.
+        documents:
+            actors: cypress/fixtures/actors
+
     # Emitted as declared. The identity, the four release addresses, the
     # version, the compatibility range and the pack list are derived instead,
     # and are refused if also declared here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/package-build": "^3.0.0",
+                "cypress": "^15.21.1",
+                "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
                 "sass": "^1.103.1",
                 "vitest": "^3.2.7"
@@ -369,6 +371,56 @@
             },
             "engines": {
                 "node": ">= 20.12.0"
+            }
+        },
+        "node_modules/@cypress/request": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+            "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~4.0.4",
+                "http-signature": "~1.4.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "performance-now": "^2.1.0",
+                "qs": "^6.15.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "^5.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "engines": {
+                "node": ">= 14.17.0"
+            }
+        },
+        "node_modules/@cypress/xvfb": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+            "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^3.1.0",
+                "lodash.once": "^4.1.1"
+            }
+        },
+        "node_modules/@cypress/xvfb/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.1"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -1789,6 +1841,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/sinonjs__fake-timers": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+            "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/sizzle": {
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+            "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/tmp": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/unist": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -1955,6 +2028,22 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/ansi-escapes": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
@@ -1980,6 +2069,27 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/arch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+            "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/archiver": {
             "version": "8.0.0",
@@ -2058,6 +2168,16 @@
                 "safer-buffer": "~2.1.0"
             }
         },
+        "node_modules/assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2085,6 +2205,23 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2100,6 +2237,23 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws4": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/b4a": {
             "version": "1.8.1",
@@ -2242,6 +2396,20 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "node_modules/blob-util": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+            "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/brace-expansion": {
             "version": "5.0.9",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -2330,6 +2498,16 @@
                 "node": ">=20.19.0"
             }
         },
+        "node_modules/cachedir": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+            "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -2379,6 +2557,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/chai": {
             "version": "5.3.3",
@@ -2469,6 +2654,43 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/chrome-remote-interface": {
+            "version": "0.33.3",
+            "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz",
+            "integrity": "sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "2.11.x",
+                "ws": "^7.2.0"
+            },
+            "bin": {
+                "chrome-remote-interface": "bin/client.js"
+            }
+        },
+        "node_modules/chrome-remote-interface/node_modules/commander": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/classic-level": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-3.0.0.tgz",
@@ -2484,6 +2706,110 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-table3": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+            "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": "10.* || >= 12.*"
+            },
+            "optionalDependencies": {
+                "colors": "1.4.0"
+            }
+        },
+        "node_modules/cli-table3/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-truncate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+            "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "slice-ansi": "^8.0.0",
+                "string-width": "^8.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cliui": {
@@ -2536,6 +2862,37 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -2544,6 +2901,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
+            }
+        },
+        "node_modules/common-tags": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/compress-commons": {
@@ -2665,6 +3032,201 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/cypress": {
+            "version": "15.21.1",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.21.1.tgz",
+            "integrity": "sha512-ogHpHMj0XNlZA5MGzjg8SWHf0eMw9lTwVQRKjpcT1GzNTxNUjwnHA8YCG6nOJ8ThU+XZaUxJgpMYZnJ//8aDaw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cypress/request": "^4.0.0",
+                "@cypress/xvfb": "^1.2.4",
+                "@types/sinonjs__fake-timers": "8.1.1",
+                "@types/sizzle": "^2.3.2",
+                "@types/tmp": "^0.2.3",
+                "arch": "^3.0.0",
+                "blob-util": "^2.0.2",
+                "bluebird": "^3.7.2",
+                "buffer": "^5.7.1",
+                "cachedir": "^2.4.0",
+                "chalk": "^4.1.0",
+                "chrome-remote-interface": "0.33.3",
+                "ci-info": "^4.1.0",
+                "cli-table3": "0.6.1",
+                "commander": "^6.2.1",
+                "common-tags": "^1.8.0",
+                "dayjs": "^1.10.4",
+                "debug": "^4.3.4",
+                "eventemitter2": "6.4.7",
+                "execa": "4.1.0",
+                "executable": "^4.1.1",
+                "fs-extra": "^9.1.0",
+                "hasha": "5.2.2",
+                "is-installed-globally": "~0.4.0",
+                "listr2": "^9.0.5",
+                "lodash": "^4.17.23",
+                "log-symbols": "^4.0.0",
+                "minimist": "^1.2.8",
+                "ospath": "^1.2.2",
+                "pretty-bytes": "^5.6.0",
+                "process": "^0.11.10",
+                "proxy-from-env": "1.0.0",
+                "request-progress": "^3.0.0",
+                "supports-color": "^8.1.1",
+                "systeminformation": "^5.31.1",
+                "tmp": "~0.2.4",
+                "tree-kill": "1.2.2",
+                "untildify": "^4.0.0",
+                "yauzl": "^3.3.1"
+            },
+            "bin": {
+                "cypress": "bin/cypress"
+            },
+            "engines": {
+                "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/cypress/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/cypress/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/cypress/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/cypress/node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cypress/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/cypress/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cypress/node_modules/commander": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/cypress/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cypress/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2718,6 +3280,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/dayjs": {
+            "version": "1.11.23",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+            "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -2797,6 +3366,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2860,12 +3439,33 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
         "node_modules/emoji-regex": {
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/entities": {
             "version": "4.5.0",
@@ -2878,6 +3478,19 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/error-ex": {
@@ -3161,6 +3774,20 @@
                 "node": ">=6"
             }
         },
+        "node_modules/eventemitter2": {
+            "version": "6.4.7",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+            "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3181,6 +3808,73 @@
                 "bare-events": "^2.7.0"
             }
         },
+        "node_modules/execa": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+            "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/execa/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/execa/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/executable": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+            "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pify": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/executable/node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/expect-type": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -3190,6 +3884,13 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/extend-shallow": {
             "version": "2.0.1",
@@ -3203,6 +3904,16 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "license": "MIT"
         },
         "node_modules/fast-fifo": {
             "version": "1.3.2",
@@ -3316,6 +4027,49 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/fsevents": {
@@ -3449,6 +4203,22 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-symbol-description": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3465,6 +4235,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
             }
         },
         "node_modules/glob": {
@@ -3503,6 +4283,22 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/global-dirs": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+            "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globalthis": {
@@ -3706,6 +4502,36 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/hasha": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+            "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-stream": "^2.0.0",
+                "type-fest": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/hasha/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -3726,6 +4552,21 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/http-signature": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+            "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^2.0.2",
+                "sshpk": "^1.18.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/human-id": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.1.tgz",
@@ -3734,6 +4575,16 @@
             "license": "MIT",
             "bin": {
                 "human-id": "dist/cli.js"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.12.0"
             }
         },
         "node_modules/ieee754": {
@@ -3798,6 +4649,16 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -4086,6 +4947,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-generator-function": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -4128,6 +5005,33 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-installed-globally": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+            "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "global-dirs": "^3.0.0",
+                "is-path-inside": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-installed-globally/node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-map": {
@@ -4308,6 +5212,26 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -4368,6 +5292,13 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/jackspeak": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -4421,6 +5352,13 @@
                 "js-yaml": "bin/js-yaml.mjs"
             }
         },
+        "node_modules/jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -4428,12 +5366,39 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-schema": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+            "dev": true,
+            "license": "(AFL-2.1 OR BSD-3-Clause)"
+        },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/jsonc-parser": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
             "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
         },
         "node_modules/jsonpointer": {
             "version": "5.0.1",
@@ -4443,6 +5408,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/jsprim": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+            "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.4.0",
+                "verror": "1.10.0"
             }
         },
         "node_modules/katex": {
@@ -4590,6 +5571,24 @@
                 "uc.micro": "^2.0.0"
             }
         },
+        "node_modules/listr2": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+            "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cli-truncate": "^5.0.0",
+                "colorette": "^2.0.20",
+                "eventemitter3": "^5.0.1",
+                "log-update": "^6.1.0",
+                "rfdc": "^1.4.1",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -4614,6 +5613,163 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "lie": "3.1.1"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-symbols/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/log-symbols/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/log-symbols/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/log-symbols/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/log-update": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "cli-cursor": "^5.0.0",
+                "slice-ansi": "^7.1.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/log-update/node_modules/slice-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
         "node_modules/loglevel": {
@@ -4814,6 +5970,13 @@
             "engines": {
                 "node": ">= 0.10.0"
             }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5375,6 +6538,52 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimatch": {
             "version": "10.2.6",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -5680,6 +6889,19 @@
                 "which": "bin/which"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -5723,6 +6945,39 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ospath": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+            "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/own-keys": {
             "version": "1.0.2",
@@ -5855,6 +7110,20 @@
                 "node": ">= 14.16"
             }
         },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5953,6 +7222,19 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/pretty-bytes": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+            "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5970,6 +7252,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/punycode.js": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -5978,6 +7278,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -6107,6 +7424,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/request-progress": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+            "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "throttleit": "^1.0.0"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.22.12",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -6129,6 +7456,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/restore-cursor": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/restore-cursor/node_modules/onetime": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/reusify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6139,6 +7499,13 @@
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/rfdc": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/rollup": {
             "version": "4.63.0",
@@ -6539,6 +7906,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/slice-ansi": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+            "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.3",
+                "is-fullwidth-code-point": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/smol-toml": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
@@ -6649,6 +8046,32 @@
             "funding": {
                 "type": "individual",
                 "url": "https://square.link/u/4g7sPflL"
+            }
+        },
+        "node_modules/sshpk": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            },
+            "bin": {
+                "sshpk-conv": "bin/sshpk-conv",
+                "sshpk-sign": "bin/sshpk-sign",
+                "sshpk-verify": "bin/sshpk-verify"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/stackback": {
@@ -6833,6 +8256,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/strip-literal": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -6872,6 +8305,33 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/systeminformation": {
+            "version": "5.33.3",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.3.tgz",
+            "integrity": "sha512-CFdkRa2yfWBXtRtinSm7QbFGRntq1nC2V2hPAjfRTGwncZbNw/UWyiKDT8rZQz6MB70/3ndzP0scIR0dJHJjBA==",
+            "dev": true,
+            "license": "MIT",
+            "os": [
+                "darwin",
+                "linux",
+                "win32",
+                "freebsd",
+                "openbsd",
+                "netbsd",
+                "sunos",
+                "android"
+            ],
+            "bin": {
+                "systeminformation": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "type": "Buy me a coffee",
+                "url": "https://www.buymeacoffee.com/systeminfo"
+            }
+        },
         "node_modules/tar-stream": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
@@ -6903,6 +8363,16 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
+            }
+        },
+        "node_modules/throttleit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
+            "integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/tinybench": {
@@ -7000,6 +8470,36 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tmp": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7013,12 +8513,58 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
             "dev": true,
             "license": "Unlicense"
+        },
+        "node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
@@ -7181,6 +8727,26 @@
                 "node": ">= 0.4.12"
             }
         },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/untildify": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/util": {
             "version": "0.12.5",
             "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -7212,6 +8778,28 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "node_modules/verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "node_modules/verror/node_modules/core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vite": {
             "version": "7.3.6",
@@ -7623,6 +9211,35 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/ws": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7675,6 +9292,19 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+            "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pend": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
+        "e2e:seed": "package-build e2e seed",
+        "e2e:full": "package-build e2e run",
+        "e2e:open": "package-build e2e open",
+        "e2e:fast": "package-build e2e fast",
+        "e2e:sweep": "package-build e2e sweep",
+        "container:test": "package-build container test",
         "changeset": "changeset",
         "changeset:version": "changeset version && npm install --package-lock-only",
         "changeset:check": "changeset status --since=origin/main"
@@ -46,6 +52,8 @@
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/package-build": "^3.0.0",
+        "cypress": "^15.21.1",
+        "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",
         "sass": "^1.103.1",
         "vitest": "^3.2.7"

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -317,7 +317,7 @@
                             <input class="value" type="text" name="system.sunsign" value="{{adata.sunsign}}" data-dtype="String" />
                             {{else}}
                             <select class="value" name="system.sunsign" data-dtype="String">
-                                {{selectOptions config.sunsigns selected=adata.sunsign}}
+                                {{selectOptions (toChoices config.sunsigns) selected=adata.sunsign}}
                             </select>
                             {{/if}}
                         </div>
@@ -1222,7 +1222,7 @@
             <div class="form-group">
                 <label>Type</label>
                 <select name="system.macros.type">
-                    {{selectOptions macroTypes selected=adata.macros.type}}
+                    {{selectOptions (toChoices macroTypes) selected=adata.macros.type}}
                 </select>
             </div>
         

--- a/templates/actor/creature-sheet.html
+++ b/templates/actor/creature-sheet.html
@@ -902,7 +902,7 @@
             <div class="form-group">
                 <label>Type</label>
                 <select name="system.macros.type">
-                    {{selectOptions macroTypes selected=adata.macros.type}}
+                    {{selectOptions (toChoices macroTypes) selected=adata.macros.type}}
                 </select>
             </div>
         

--- a/templates/dialog/attack-dialog.html
+++ b/templates/dialog/attack-dialog.html
@@ -37,7 +37,7 @@
     <div class="form-group">
         <label>Aim:</label>
         <select name="aim">
-            {{selectOptions aimLocations selected=defaultAim}}
+            {{selectOptions (toChoices aimLocations) selected=defaultAim}}
         </select>
     </div>
 

--- a/templates/dialog/create-item.html
+++ b/templates/dialog/create-item.html
@@ -7,7 +7,7 @@
         <label>{{extraLabel}}</label>
         {{#if extraList}}
         <select class="resource-value" name="extra_value" data-dtype="String">
-            {{selectOptions extraList selected=extra_value}}
+            {{selectOptions (toChoices extraList) selected=extra_value}}
         </select>
         {{else}}
         <input type="text" name="extra_value" data-dtype="String"/>

--- a/templates/dialog/injury-dialog.html
+++ b/templates/dialog/injury-dialog.html
@@ -10,7 +10,7 @@
     <div class="form-group">
         <label>Location:</label>
         <select name="location">
-            {{selectOptions hitLocations selected=location}}
+            {{selectOptions (toChoices hitLocations) selected=location}}
         </select>
     </div>
 

--- a/templates/dialog/query-weapon-dialog.html
+++ b/templates/dialog/query-weapon-dialog.html
@@ -3,7 +3,7 @@
     <div class="form-group">
         <label>Weapon:</label>
         <select name="weapon">
-            {{selectOptions weapons selected=defaultWeapon}}
+            {{selectOptions (toChoices weapons) selected=defaultWeapon}}
         </select>
     </div>
 

--- a/templates/item/armorlocation-sheet.html
+++ b/templates/item/armorlocation-sheet.html
@@ -114,23 +114,23 @@
                 <div class="item flexrow">
                     <select class="armorlocation-effimp-item" id="armorlocation-effimp-ei1"
                         name="system.effectiveImpact.ei1" data-dtype="String">
-                        {{selectOptions config.injuryLevels selected=idata.effectiveImpact.ei1}}
+                        {{selectOptions (toChoices config.injuryLevels) selected=idata.effectiveImpact.ei1}}
                     </select>
                     <select class="armorlocation-effimp-item" id="armorlocation-effimp-ei5"
                         name="system.effectiveImpact.ei5" data-dtype="String">
-                        {{selectOptions config.injuryLevels selected=idata.effectiveImpact.ei5}}
+                        {{selectOptions (toChoices config.injuryLevels) selected=idata.effectiveImpact.ei5}}
                     </select>
                     <select class="armorlocation-effimp-item" id="armorlocation-effimp-ei9"
                         name="system.effectiveImpact.ei9" data-dtype="String">
-                        {{selectOptions config.injuryLevels selected=idata.effectiveImpact.ei9}}
+                        {{selectOptions (toChoices config.injuryLevels) selected=idata.effectiveImpact.ei9}}
                     </select>
                     <select class="armorlocation-effimp-item" id="armorlocation-effimp-ei13"
                         name="system.effectiveImpact.ei13" data-dtype="String">
-                        {{selectOptions config.injuryLevels selected=idata.effectiveImpact.ei13}}
+                        {{selectOptions (toChoices config.injuryLevels) selected=idata.effectiveImpact.ei13}}
                     </select>
                     <select class="armorlocation-effimp-item" id="armorlocation-effimp-ei17"
                         name="system.effectiveImpact.ei17" data-dtype="String">
-                        {{selectOptions config.injuryLevels selected=idata.effectiveImpact.ei17}}
+                        {{selectOptions (toChoices config.injuryLevels) selected=idata.effectiveImpact.ei17}}
                     </select>
                 </div>
             </fieldset>

--- a/templates/item/invocation-sheet.html
+++ b/templates/item/invocation-sheet.html
@@ -24,7 +24,7 @@
                     <label class="resource-label" for="system.diety">Diety</label>
                     {{#if hasRitualSkills}}
                         <select class="resource-value" name="system.diety" data-dtype="String">
-                            {{selectOptions dieties selected=idata.diety}}
+                            {{selectOptions (toChoices dieties) selected=idata.diety}}
                         </select>
                     {{else}}
                         <input type="text" name="system.diety" value="{{idata.diety}}" data-dtype="String" />
@@ -55,7 +55,7 @@
             <div class="form-group">
                 <label>Type</label>
                 <select name="system.macros.type">
-                    {{selectOptions macroTypes selected=idata.macros.type}}
+                    {{selectOptions (toChoices macroTypes) selected=idata.macros.type}}
                 </select>
             </div>
         

--- a/templates/item/missilegear-sheet.html
+++ b/templates/item/missilegear-sheet.html
@@ -47,14 +47,14 @@
                 <div class="resource" id="missilegear=weaponaspect">
                     <label class="resource-label" for="system.weaponAspect">Weapon Aspect</label>
                     <select class="resource-value" name="system.weaponAspect" data-dtype="String">
-                        {{selectOptions config.allowedAspects selected=idata.weaponAspect}}
+                        {{selectOptions (toChoices config.allowedAspects) selected=idata.weaponAspect}}
                     </select>
                 </div>
                 <div class="resource" id="missilegear-assocskill">
                     <label class="resource-label" for="system.assocSkill">Associated Skill</label>
                     {{#if hasCombatSkills}}
                         <select class="resource-value" name="system.assocSkill" data-dtype="String">
-                            {{selectOptions combatSkills selected=idata.assocSkill}}
+                            {{selectOptions (toChoices combatSkills) selected=idata.assocSkill}}
                         </select>
                     {{else}}
                         <input type="text" name="system.assocSkill" value="{{idata.assocSkill}}" data-dtype="String" />

--- a/templates/item/psionic-sheet.html
+++ b/templates/item/psionic-sheet.html
@@ -68,7 +68,7 @@
             <div class="form-group">
                 <label>Type</label>
                 <select name="system.macros.type">
-                    {{selectOptions macroTypes selected=idata.macros.type}}
+                    {{selectOptions (toChoices macroTypes) selected=idata.macros.type}}
                 </select>
             </div>
         

--- a/templates/item/skill-sheet.html
+++ b/templates/item/skill-sheet.html
@@ -7,7 +7,7 @@
                 <div class="skill-type flexrow">
                     <label class="label">Type</label>
                     <select class="value" name="system.type">
-                        {{selectOptions config.skillTypes selected=idata.type}}
+                        {{selectOptions (toChoices config.skillTypes) selected=idata.type}}
                     </select>
                 </div>
             </div>
@@ -79,7 +79,7 @@
             <div class="form-group">
                 <label>Type</label>
                 <select name="system.macros.type">
-                    {{selectOptions macroTypes selected=idata.macros.type}}
+                    {{selectOptions (toChoices macroTypes) selected=idata.macros.type}}
                 </select>
             </div>
         

--- a/templates/item/spell-sheet.html
+++ b/templates/item/spell-sheet.html
@@ -24,7 +24,7 @@
                     <label class="resource-label" for="system.convocation">Convocation</label>
                     {{#if hasMagicSkills}}
                         <select class="resource-value" name="system.convocation" data-dtype="String">
-                            {{selectOptions convocations selected=idata.convocation}}
+                            {{selectOptions (toChoices convocations) selected=idata.convocation}}
                         </select>
                     {{else}}
                         <input type="text" name="system.convocation" value="{{idata.convocation}}" data-dtype="String" />
@@ -55,7 +55,7 @@
             <div class="form-group">
                 <label>Type</label>
                 <select name="system.macros.type">
-                    {{selectOptions macroTypes selected=idata.macros.type}}
+                    {{selectOptions (toChoices macroTypes) selected=idata.macros.type}}
                 </select>
             </div>
         

--- a/templates/item/trait-sheet.html
+++ b/templates/item/trait-sheet.html
@@ -7,7 +7,7 @@
                 <div class="skill-type flexrow">
                     <label class="label">Type</label>
                     <select class="value" name="system.type">
-                        {{selectOptions config.traitTypes selected=idata.type}}
+                        {{selectOptions (toChoices config.traitTypes) selected=idata.type}}
                     </select>
                 </div>
             </div>

--- a/templates/item/weapongear-sheet.html
+++ b/templates/item/weapongear-sheet.html
@@ -81,7 +81,7 @@
                     <label class="resource-label" for="system.assocSkill">Associated Skill</label>
                     {{#if hasCombatSkills}}
                         <select class="resource-value" name="system.assocSkill" data-dtype="String">
-                            {{selectOptions combatSkills selected=idata.assocSkill}}
+                            {{selectOptions (toChoices combatSkills) selected=idata.assocSkill}}
                         </select>
                     {{else}}
                         <input type="text" name="system.assocSkill" value="{{idata.assocSkill}}" data-dtype="String" />


### PR DESCRIPTION
## What

An end-to-end harness that drives a real Foundry, in a real browser, against a
disposable world. **31 specs, all passing on 14.364.**

And two regressions it found, fixed in `cc9a662`.

## Why now

The v14 release (#406) shipped on static verification alone. A green build says
the packs compiled; it says nothing about a system that used to die in its
`init` hook, and nothing about sheets whose entire application framework changed
underneath them. The PR listed what that left unverified. This closes it.

## The regressions it found

Both shipped in #406. Both survived review because both are valid JavaScript
against an API that still exists — only running them shows the API now returns
nothing useful.

**Every ability roll threw.** `Object.keys(game.model.Actor.character.abilities)`
— `game.model` is Foundry's registry of `template.json` defaults, and #406
replaced template.json with data models, leaving it empty. Two more readers of
the same registry went with it: the armour-location defaults and the migration's
field scrub.

**Twenty-three dropdowns silently lost their value.** `selectOptions` numbers a
plain array — `["Craft", …]` renders `<option value="0">Craft</option>` — where
the `{{#select}}` blocks they replaced rendered `value="{{this}}"`. So the stored
value matched nothing, and **saving a sheet would have written the option's index
into the field.** Skill and trait type, weapon aspect, convocation, deity,
sunsign, armour effective-impact, macro type, and more.

That second one is data corruption on save, in a released build.

## Coverage, against the manual test plan

| Plan | Covered |
|---|---|
| 0.7 | `init` completes; document classes, data models and Hârnic fonts registered |
| 1.1 | All three actor sheets open as ApplicationV2; tabs switch |
| — | An item sheet renders for each of the twelve item types |
| 2.4 | Dropdowns keep their stored value across render and re-render |
| 5, App. A | Rolls reach chat with the roll attached, the author set, a valid style |
| — | Chat card buttons respond (dead from v13 until #406) |
| 9.1 | Active effects create, and the config offers HM3's key list |

Not yet covered: automated combat (6–7), injuries (8), macros (10), gear tab
(11), settings (12), edge cases (13), weapon behaviours (14).

Part 0's four actors are seeded from the plan's own ability tables, deliberately
**without items** — the plan builds those by dragging from compendiums, and those
drags are themselves under test.

## One instance, many worlds

Foundry signs a licence to the container **hostname**:

```
Config/license.json -> { host: "sohl-foundry-test", …, signature: … }
```

So a shared e2e installation — one Foundry, every system under `Data/systems/`,
a world per package under `Data/worlds/` — needs **one** signed licence, where a
container per package would need one each. That is the model here.

### Known limitation

`package-build` derives the container name from the package id and sets
`--hostname` to match. Correct for a licence per package; wrong for a shared
instance — and it is the only thing stopping `npm run e2e:full` and
`npm run e2e:sweep` from driving this directly.

The container is started by hand meanwhile; `cypress/README.md` carries the
command and the reasoning. **The proper fix is a container-name option in
`@heroiclands/package-build`**, which would also let SoHL and kethira share the
instance. I have not made that change — it is another repository and wants its
own decision.

## Verification

- `npx cypress run` — 31/31 passing against Foundry 14.364.
- `npm test` — 138 unit tests still passing.
- `npm run build:noci` — clean, 674 documents across 4 packs.
