### PR TITLE
feat(content): add an Armor Locations folder to the items pack

### DIFF
--- a/.changeset/armor-locations-items.md
+++ b/.changeset/armor-locations-items.md
@@ -1,0 +1,16 @@
+---
+"hm3": minor
+---
+
+Added: the 24 standard armor locations as compendium items.
+
+The `items` pack held every other kind of item a being needs — skills, armor,
+weapons, gear, invocations — but no `armorlocation` documents. They existed only
+as items already embedded on pre-built actors, so there was nothing to drag onto
+a new actor and no way to repair a being whose locations had been deleted short
+of copying them off another one.
+
+A new top-level `Armor Locations` folder now carries Skull, Face, Neck and the
+paired shoulders through feet. Their data is lifted from a set already in play
+rather than authored afresh, so the impact types, effective-impact ladders and
+probability weights are the ones actors have been using, not new numbers.

--- a/assets/packs/items/Abdomen_JC0lU9gAOYW34KRO.json
+++ b/assets/packs/items/Abdomen_JC0lU9gAOYW34KRO.json
@@ -1,0 +1,52 @@
+{
+  "_id": "JC0lU9gAOYW34KRO",
+  "name": "Abdomen",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "abdm"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": false,
+    "isAmputate": false,
+    "impactType": "abdomen",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "K4",
+      "ei17": "K5"
+    },
+    "probWeight": {
+      "high": 60,
+      "mid": 100,
+      "low": 100
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!JC0lU9gAOYW34KRO"
+}

--- a/assets/packs/items/Face_3dqT2MquaOBi0j3z.json
+++ b/assets/packs/items/Face_3dqT2MquaOBi0j3z.json
@@ -1,0 +1,52 @@
+{
+  "_id": "3dqT2MquaOBi0j3z",
+  "name": "Face",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "face"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": false,
+    "isAmputate": false,
+    "impactType": "face",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K5"
+    },
+    "probWeight": {
+      "high": 150,
+      "mid": 50,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!3dqT2MquaOBi0j3z"
+}

--- a/assets/packs/items/Groin_SqQ0wx8ypIPsmW04.json
+++ b/assets/packs/items/Groin_SqQ0wx8ypIPsmW04.json
@@ -1,0 +1,52 @@
+{
+  "_id": "SqQ0wx8ypIPsmW04",
+  "name": "Groin",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "groin"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "groin",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 40,
+      "low": 60
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!SqQ0wx8ypIPsmW04"
+}

--- a/assets/packs/items/Left_Calf_l68U7VK24LiVsW0h.json
+++ b/assets/packs/items/Left_Calf_l68U7VK24LiVsW0h.json
@@ -1,0 +1,52 @@
+{
+  "_id": "l68U7VK24LiVsW0h",
+  "name": "Left Calf",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lcalf"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "calf",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "M1",
+      "ei9": "S2",
+      "ei13": "S3",
+      "ei17": "G4"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 30,
+      "low": 70
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!l68U7VK24LiVsW0h"
+}

--- a/assets/packs/items/Left_Elbow_znvIYZmbE5fhuNUe.json
+++ b/assets/packs/items/Left_Elbow_znvIYZmbE5fhuNUe.json
@@ -1,0 +1,52 @@
+{
+  "_id": "znvIYZmbE5fhuNUe",
+  "name": "Left Elbow",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lelb"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "elbow",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 20,
+      "mid": 10,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!znvIYZmbE5fhuNUe"
+}

--- a/assets/packs/items/Left_Foot_U43cl7n1mJGXZkyn.json
+++ b/assets/packs/items/Left_Foot_U43cl7n1mJGXZkyn.json
@@ -1,0 +1,52 @@
+{
+  "_id": "U43cl7n1mJGXZkyn",
+  "name": "Left Foot",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lfoot"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "foot",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 20,
+      "low": 40
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!U43cl7n1mJGXZkyn"
+}

--- a/assets/packs/items/Left_Hand_LTy8EKm3KRzzBVDX.json
+++ b/assets/packs/items/Left_Hand_LTy8EKm3KRzzBVDX.json
@@ -1,0 +1,52 @@
+{
+  "_id": "LTy8EKm3KRzzBVDX",
+  "name": "Left Hand",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lhand"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "hand",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 20,
+      "mid": 20,
+      "low": 30
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!LTy8EKm3KRzzBVDX"
+}

--- a/assets/packs/items/Left_Hip_iKMNXeV0mNDtgZTa.json
+++ b/assets/packs/items/Left_Hip_iKMNXeV0mNDtgZTa.json
@@ -1,0 +1,52 @@
+{
+  "_id": "iKMNXeV0mNDtgZTa",
+  "name": "Left Hip",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lhip"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": false,
+    "impactType": "hip",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K4"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 30,
+      "low": 70
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!iKMNXeV0mNDtgZTa"
+}

--- a/assets/packs/items/Left_Knee_6mlN3i7tORdx9LWF.json
+++ b/assets/packs/items/Left_Knee_6mlN3i7tORdx9LWF.json
@@ -1,0 +1,52 @@
+{
+  "_id": "6mlN3i7tORdx9LWF",
+  "name": "Left Knee",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lknee"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "knee",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 10,
+      "low": 40
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!6mlN3i7tORdx9LWF"
+}

--- a/assets/packs/items/Left_Shoulder_wyNYXtlqEU6QpGBQ.json
+++ b/assets/packs/items/Left_Shoulder_wyNYXtlqEU6QpGBQ.json
@@ -1,0 +1,52 @@
+{
+  "_id": "wyNYXtlqEU6QpGBQ",
+  "name": "Left Shoulder",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lshoulder"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": false,
+    "impactType": "shoulder",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K4"
+    },
+    "probWeight": {
+      "high": 60,
+      "mid": 60,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!wyNYXtlqEU6QpGBQ"
+}

--- a/assets/packs/items/Left_Thigh_ysoQMtIXQeu7aTOU.json
+++ b/assets/packs/items/Left_Thigh_ysoQMtIXQeu7aTOU.json
@@ -1,0 +1,52 @@
+{
+  "_id": "ysoQMtIXQeu7aTOU",
+  "name": "Left Thigh",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "lthigh"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "thigh",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K4"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 40,
+      "low": 100
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!ysoQMtIXQeu7aTOU"
+}

--- a/assets/packs/items/Left_Upper_Arm_da76tICZGujy7KJi.json
+++ b/assets/packs/items/Left_Upper_Arm_da76tICZGujy7KJi.json
@@ -1,0 +1,52 @@
+{
+  "_id": "da76tICZGujy7KJi",
+  "name": "Left Upper Arm",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "luparm"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "upperarm",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "M1",
+      "ei9": "S2",
+      "ei13": "S3",
+      "ei17": "G4"
+    },
+    "probWeight": {
+      "high": 60,
+      "mid": 30,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!da76tICZGujy7KJi"
+}

--- a/assets/packs/items/Neck_1RVcbeArRw7uyLM3.json
+++ b/assets/packs/items/Neck_1RVcbeArRw7uyLM3.json
@@ -1,0 +1,52 @@
+{
+  "_id": "1RVcbeArRw7uyLM3",
+  "name": "Neck",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "neck"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "neck",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "K4",
+      "ei17": "K5"
+    },
+    "probWeight": {
+      "high": 150,
+      "mid": 50,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!1RVcbeArRw7uyLM3"
+}

--- a/assets/packs/items/Right_Calf_x1VfXB9F7i2TGgqu.json
+++ b/assets/packs/items/Right_Calf_x1VfXB9F7i2TGgqu.json
@@ -1,0 +1,52 @@
+{
+  "_id": "x1VfXB9F7i2TGgqu",
+  "name": "Right Calf",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "rcalf"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "calf",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "M1",
+      "ei9": "S2",
+      "ei13": "S3",
+      "ei17": "G4"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 30,
+      "low": 70
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!x1VfXB9F7i2TGgqu"
+}

--- a/assets/packs/items/Right_Elbow_32pLxncIyWhJBV7V.json
+++ b/assets/packs/items/Right_Elbow_32pLxncIyWhJBV7V.json
@@ -1,0 +1,52 @@
+{
+  "_id": "32pLxncIyWhJBV7V",
+  "name": "Right Elbow",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "relb"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "elbow",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 20,
+      "mid": 10,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!32pLxncIyWhJBV7V"
+}

--- a/assets/packs/items/Right_Foot_T2dm7AwEzpfoo8Xx.json
+++ b/assets/packs/items/Right_Foot_T2dm7AwEzpfoo8Xx.json
@@ -1,0 +1,52 @@
+{
+  "_id": "T2dm7AwEzpfoo8Xx",
+  "name": "Right Foot",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "rfoot"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "foot",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 20,
+      "low": 40
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!T2dm7AwEzpfoo8Xx"
+}

--- a/assets/packs/items/Right_Hand_HXxPGxRL1F7RWsUJ.json
+++ b/assets/packs/items/Right_Hand_HXxPGxRL1F7RWsUJ.json
@@ -1,0 +1,52 @@
+{
+  "_id": "HXxPGxRL1F7RWsUJ",
+  "name": "Right Hand",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "rhand"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "hand",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 20,
+      "mid": 20,
+      "low": 30
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!HXxPGxRL1F7RWsUJ"
+}

--- a/assets/packs/items/Right_Hip_BvzcVDVLviUY8CGt.json
+++ b/assets/packs/items/Right_Hip_BvzcVDVLviUY8CGt.json
@@ -1,0 +1,52 @@
+{
+  "_id": "BvzcVDVLviUY8CGt",
+  "name": "Right Hip",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "rhip"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": false,
+    "impactType": "hip",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K4"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 30,
+      "low": 70
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!BvzcVDVLviUY8CGt"
+}

--- a/assets/packs/items/Right_Knee_47PhEb7XsH1x8gtw.json
+++ b/assets/packs/items/Right_Knee_47PhEb7XsH1x8gtw.json
@@ -1,0 +1,52 @@
+{
+  "_id": "47PhEb7XsH1x8gtw",
+  "name": "Right Knee",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "rknee"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "knee",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "G5"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 10,
+      "low": 40
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!47PhEb7XsH1x8gtw"
+}

--- a/assets/packs/items/Right_Shoulder_1d2BrZIOjfr8bZns.json
+++ b/assets/packs/items/Right_Shoulder_1d2BrZIOjfr8bZns.json
@@ -1,0 +1,52 @@
+{
+  "_id": "1d2BrZIOjfr8bZns",
+  "name": "Right Shoulder",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "rshoulder"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": false,
+    "impactType": "shoulder",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K4"
+    },
+    "probWeight": {
+      "high": 60,
+      "mid": 60,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!1d2BrZIOjfr8bZns"
+}

--- a/assets/packs/items/Right_Thigh_DxhJ9mRhaGiaXWmn.json
+++ b/assets/packs/items/Right_Thigh_DxhJ9mRhaGiaXWmn.json
@@ -1,0 +1,52 @@
+{
+  "_id": "DxhJ9mRhaGiaXWmn",
+  "name": "Right Thigh",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "rthigh"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": true,
+    "isAmputate": true,
+    "impactType": "thigh",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K4"
+    },
+    "probWeight": {
+      "high": 0,
+      "mid": 40,
+      "low": 100
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!DxhJ9mRhaGiaXWmn"
+}

--- a/assets/packs/items/Right_Upper_Arm_K6ofefzJwy8KORTH.json
+++ b/assets/packs/items/Right_Upper_Arm_K6ofefzJwy8KORTH.json
@@ -1,0 +1,52 @@
+{
+  "_id": "K6ofefzJwy8KORTH",
+  "name": "Right Upper Arm",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "ruparm"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": true,
+    "isStumble": false,
+    "isAmputate": true,
+    "impactType": "upperarm",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "M1",
+      "ei9": "S2",
+      "ei13": "S3",
+      "ei17": "G4"
+    },
+    "probWeight": {
+      "high": 60,
+      "mid": 30,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!K6ofefzJwy8KORTH"
+}

--- a/assets/packs/items/Skull_1FAZZkjhpS0j0V5t.json
+++ b/assets/packs/items/Skull_1FAZZkjhpS0j0V5t.json
@@ -1,0 +1,52 @@
+{
+  "_id": "1FAZZkjhpS0j0V5t",
+  "name": "Skull",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "skull"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": false,
+    "isAmputate": false,
+    "impactType": "skull",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "K4",
+      "ei17": "K5"
+    },
+    "probWeight": {
+      "high": 150,
+      "mid": 50,
+      "low": 0
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!1FAZZkjhpS0j0V5t"
+}

--- a/assets/packs/items/Thorax_lV9WNZoWhcbYk3cH.json
+++ b/assets/packs/items/Thorax_lV9WNZoWhcbYk3cH.json
@@ -1,0 +1,52 @@
+{
+  "_id": "lV9WNZoWhcbYk3cH",
+  "name": "Thorax",
+  "type": "armorlocation",
+  "img": "icons/svg/item-bag.svg",
+  "effects": [],
+  "folder": "clZ7CX2Ai8QyzZj0",
+  "flags": {
+    "core": {},
+    "sohl": {
+      "shortcode": "thorax"
+    }
+  },
+  "system": {
+    "layers": "",
+    "armorQuality": 0,
+    "blunt": 0,
+    "edged": 0,
+    "piercing": 0,
+    "fire": 0,
+    "isFumble": false,
+    "isStumble": false,
+    "isAmputate": false,
+    "impactType": "thorax",
+    "effectiveImpact": {
+      "ei1": "M1",
+      "ei5": "S2",
+      "ei9": "S3",
+      "ei13": "G4",
+      "ei17": "K5"
+    },
+    "probWeight": {
+      "high": 100,
+      "mid": 170,
+      "low": 70
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "gaRXj6PUpj4nuJ7Y": 3
+  },
+  "_key": "!items!lV9WNZoWhcbYk3cH"
+}

--- a/assets/packs/items/folder_Armor_Locations_clZ7CX2Ai8QyzZj0.json
+++ b/assets/packs/items/folder_Armor_Locations_clZ7CX2Ai8QyzZj0.json
@@ -1,0 +1,23 @@
+{
+  "name": "Armor Locations",
+  "sorting": "a",
+  "folder": null,
+  "type": "Item",
+  "_id": "clZ7CX2Ai8QyzZj0",
+  "sort": 0,
+  "color": null,
+  "flags": {
+    "sohl": {
+      "shortcode": "armorlocations"
+    }
+  },
+  "_stats": {
+    "systemId": "hm3",
+    "systemVersion": "1.4.6",
+    "coreVersion": "11.305",
+    "createdTime": 1689284843915,
+    "modifiedTime": 1689285072071,
+    "lastModifiedBy": "gaRXj6PUpj4nuJ7Y"
+  },
+  "_key": "!folders!clZ7CX2Ai8QyzZj0"
+}


### PR DESCRIPTION
Closes #415

The `items` compendium shipped no `armorlocation` documents. Every other item
type a being needs was there; armor locations existed only as items already
embedded on a pre-built actor, so there was nothing to drag onto a new actor and
no way to repair a being whose locations were missing short of copying them off
another one.

## What this adds

A top-level `Armor Locations` folder and the 24 standard human locations under
it — Skull, Face, Neck, and the paired shoulders through feet. 25 documents.

The `system` payloads are lifted **verbatim** from a Huscarl already in play, so
the impact types, effective-impact ladders, probability weights and the
fumble/stumble/amputate flags are the numbers actors already use rather than
values invented for this PR.

## Conventions followed

Each document matches the pack it lands in rather than the actor it came from:

- Shortcodes under `flags.sohl.shortcode` (`skull`, `lshoulder`, `abdm`, …) —
  the namespace all 1,552 existing pack documents use. The actor-embedded copies
  use `flags.hm3`; that form was not carried over.
- Filenames follow the pack rule (`[^A-Za-z0-9]` → `_`, then `_<id>.json`, with
  the `folder_` prefix on the folder).
- `_stats`, `ownership`, `sorting: "a"` and `sort: 0` match the sibling
  documents and the other 54 folders, and the JSON key ordering matches too.

`_id`s are 16-character Foundry-alphabet strings derived deterministically from
each document name, checked against every existing `_id` in the pack — no
collisions. Being deterministic, regenerating them yields the same ids rather
than churning document identity.

## Verification

`npm run build:compiledb` compiles the pack to LevelDB at **1,577 documents**
(1,552 + 25). Extracting that LevelDB back out recovers all 24 armorlocations,
every one parented to the new folder, with well-formed `!items!<id>` keys and
shortcodes intact — so the `_key` values are confirmed by a real round trip, not
just by inspection.

## Note, not part of this change

`assets/packs/items/Pence_TV3IMHs8SLZ1L1vv.json` is named with the **Cash
folder's** id while the document's own `_id` is `sR0MNABSDrVxUQMf`. It is the only
filename in the pack that breaks the naming rule. Pre-existing; left alone.