### PR TITLE
chore(devops): take @heroiclands/package-build 4.0.0

### DIFF
--- a/.changeset/package-build-4.md
+++ b/.changeset/package-build-4.md
@@ -1,0 +1,33 @@
+---
+"hm3": patch
+---
+
+Take `@heroiclands/package-build` 4.0.0, four releases on from the 3.0.1 this
+repository was pinned to.
+
+Nothing this system ships changes. The build stages the same 540 files, and 538
+of them are byte-identical to what 3.0.1 produced — the two that differ are the
+LevelDB `LOG` files, which carry wall-clock timestamps and differ between two
+runs of the *same* version. `system.json` is byte-identical, packs and all, and
+the compiled packs round-trip back to the committed JSON exactly as before.
+
+That is the expected result rather than a lucky one. HM3 uses only the packaging
+half of the toolchain, and every release in the range is a content-pass change:
+4.0.0 retires the `package:` and `draft:` frontmatter fields, 3.4.0 and 3.3.0
+change what the Markdown compilers emit. This repository has no `assets/content`
+tree, declares no `itemBuilders`, and wires none of the `content-build` commands
+into a script, so none of that code runs here. `manifest.mjs` and `stage.mjs`
+import nothing from the content engine, and the modules behind `assets`,
+`deploy` and the whole end-to-end harness are byte-identical between the two
+versions.
+
+The one packaging change that does reach us is 3.1.0's per-pack `system` key:
+the manifest now omits it where nothing declares one, instead of always writing
+the package-wide value. HM3 declares `stats.systemId: hm3`, so both packs are
+still stamped `"system": "hm3"`.
+
+3.1.0 also added two capabilities this repository is now able to consider and
+does not yet use — `packageBuild.container.name`, which would let HM3 share one
+Foundry container and so one signed licence with the other HeroicLands packages,
+and `packs[].prebuilt`, a first-class route for a package whose pack JSON is
+already built, which is exactly this repository's shape.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "devDependencies": {
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
-                "@heroiclands/package-build": "^3.0.0",
+                "@heroiclands/package-build": "^4.0.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -888,9 +888,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-3.0.1.tgz",
-            "integrity": "sha512-vFDWVLMOeYinRuvGBq252bjAKub3K2VLAnY0bMmKuJUOua8jU/xqY7Xr/hTx+1mXSgCGlaaykb7eNeZmGSXfLQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-4.0.0.tgz",
+            "integrity": "sha512-K9T1C6Bx9ljCB8KCWNXqv1zcepEPCuEqYrkiSbPrrJO5Ch5B4C1LCZ6q1jFm5km5KSw8x9kZv8nTokxU9opD/A==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "devDependencies": {
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
-        "@heroiclands/package-build": "^3.0.0",
+        "@heroiclands/package-build": "^4.0.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Take `@heroiclands/package-build` 4.0.0. This repository declared `^3.0.0` and
resolved 3.0.1 — four releases behind, the furthest back of any consumer, and a
major Dependabot could not bring in.

Only the dependency and the changeset change. `package-lock.json` moves exactly
one package.

## What can actually reach this repository

HM3 uses only the **packaging** half of the toolchain. Its compendium content is
committed JSON under `assets/packs/`, compiled by `utils/compile-packs.mjs`;
there is no `assets/content` Markdown tree, no `itemBuilders`, and no
`content-build` command is wired into any npm script. So the question is not
whether the two headline retirements break us but whether they can run at all.

| Release   | Change                                                        | Reaches HM3?                                                          |
| --------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
| **4.0.0** | `package:` frontmatter rejected (#56)                         | **No** — enforced in `base-compiler`, `manifest-emit`, `frontmatter-lint`; none of the three runs here |
| **4.0.0** | `draft:` removed (#69)                                        | **No** — same three call sites                                        |
| **3.4.0** | Stop emitting `assocMysteryCode`                              | **No** — SoHL item builder; `itemBuilders` is empty here              |
| **3.4.0** | Derived package written into an emitted page's frontmatter    | **No** — `content-build site`; this repository publishes no site      |
| **3.3.0** | `package:` optional/derived; unopened skills opened at compile | **No** — content compile loop and the SoHL actors pass                |
| **3.2.0** | A system-agnostic module may stamp no system version          | **No** — reached only when neither `stats.systemId` nor a system relationship is declared; `stats.systemId: hm3` is declared, and this is a system |
| **3.1.0** | `packs[].prebuilt`                                            | **Available, unused** — implemented in `content-config`/`compendiums`, on the `content-build package compile` path this repository does not take |
| **3.1.0** | Per-pack `packs[].system`, `stats.systemId` optional          | **Yes** — the one packaging change in the range                       |
| **3.1.0** | `packageBuild.container.name`                                 | **Available, unused** — undeclared, so the name stays `hm3-foundry-<stage>` |

The one that lands is per-pack `system`. `manifestPacks` used to write
`system: config.stats.systemId` unconditionally; it now takes the pack's own
declaration first, then the package-wide one, and **omits the key when neither
is set**. HM3 declares `stats.systemId: hm3`, so both packs are still stamped
`"system": "hm3"` and the emitted manifest does not move.

Structurally the same conclusion: `manifest.mjs` and `stage.mjs` import nothing
but `node:fs` and `node:path` — no content engine at all — and `e2e.mjs`,
`deploy.mjs`, `stage.mjs`, `release.mjs`, `lang.mjs`, `bundle.mjs`,
`coverage.mjs`, `templates.mjs` and `index.mjs` are **byte-identical** between
3.0.1 and 4.0.0. No file was removed from the package.

## Verification

Built twice on 3.0.1 first, to separate inherent non-determinism from real
change, then once on 4.0.0:

|                              | Staged files | Differing                        |
| ---------------------------- | ------------ | -------------------------------- |
| 3.0.1 run A vs 3.0.1 run B   | 540          | 2 — `packs/*/LOG`                |
| 3.0.1 run B vs 4.0.0         | 540          | 2 — `packs/*/LOG`, the same two  |

**538 of 540 files byte-identical**, and the two that differ are the LevelDB
`LOG` files, which carry wall-clock timestamps and differ between two runs of
the *same* version. No file added or removed. Both packs compile the same
document counts: `items` 1,577, `system-help` 20.

`build/stage/system.json` is **byte-identical** — 22 keys, `id: hm3`, version
1.6.3, `compatibility` 14 / 14.367, and both derived `packs[]` entries including
`"system": "hm3"`.

Round-trip through `build:unpackdb` produces the same result on both versions
(see the note below). `npm test` passes 138 tests, `lint:packs` and `lint:lang`
are clean.

## The e2e harness

`e2e.mjs` is byte-identical, and `E2E_KEYS` / `E2E_SUITE_KEYS` /
`E2E_BUILD_TARGET_KEYS` / `E2E_WORLD_KEYS` / `E2E_GM_KEYS` are unchanged, so
`packageBuild.e2e` needs nothing. Loading the configuration under 4.0.0 resolves
it exactly as declared — stage `test`, the Cypress `run`/`open` suite, the four
build targets in order with `system` carrying `recreate: true`, and
`cypress/fixtures/actors`. `containerName` resolves `null`, so the container is
still `hm3-foundry-<stage>`. **No mismatch.** The suite was not run: the
container is shared and in use.

## Two things found on the way, neither caused by this bump

**`build:unpackdb` does not round-trip folder documents.** Extracting the built
packs renames all 56 folder files from `folder_<Name>_<id>.json` to
`<Name>_<id>.json` — content byte-identical, filename only. All 1,541 document
files round-trip exactly. Reproduced on 3.0.1 as well, so it predates this
change; it contradicts CONTRIBUTING.md's "round-tripping without editing
produces no diff". Filed as #419.

**`packFolders` in `package-build.config.yaml` names four packs that no longer
exist** — `character`, `possessions`, `esoteric`, `system-help` — where the
package now ships `items` and `system-help`. A leftover from the #414
consolidation. Filed as #420.

Closes #417
