### PR TITLE
Adopt @heroiclands/package-build 5.0.0, and author the package homepage

### DIFF
--- a/.changeset/package-build-5-and-homepage.md
+++ b/.changeset/package-build-5-and-homepage.md
@@ -1,0 +1,39 @@
+---
+"hm3": patch
+---
+
+Take `@heroiclands/package-build` 5.0.0, and author the package homepage it
+introduces.
+
+**Nothing this system ships changes.** The build stages the same 540 files, and
+538 of them are byte-identical to what 4.0.0 produced — the two that differ are
+the LevelDB `LOG` files, which carry wall-clock timestamps and differ between
+two runs of the _same_ version. `system.json` is byte-identical, and the packs
+compile the same 1,577 items and 20 system-help journals.
+
+**`publish.site` is a mode now, not a boolean** — `homepage` or `content`, with
+both booleans refused at config load rather than mapped onto the nearest one.
+This repository declared no `publish:` section, so nothing was refused here and
+the new default, `homepage`, already applied. It is now written out, because a
+mode inherited by omission reads to the next person as a question nobody asked.
+
+**The homepage is a page, authored rather than assembled.** 5.0.0 adds a
+`type: homepage` note that compiles to a page instead of to a compendium
+document, published at `/hm3/`. It says what the system is, the manifest URL to
+paste into Foundry, that Foundry 14 or later is needed, that you still need your
+own copy of the HârnMaster rules, and where the source and the licence are.
+Everything on it is drawn from `README.md`, `WALKTHROUGH.md` and the manifest;
+only the title is derived, and here it is authored so the page can greet a
+reader as HârnMaster rather than as the manifest's `HarnMaster 3`.
+
+Two pieces of plumbing came with it, both new to this repository:
+
+- `assets/content/` now exists, with the homepage note as its only file. HM3
+  uses only the packaging half of the toolchain — its compendium content is
+  committed JSON under `assets/packs/` — so this is not a content tree and the
+  site build walks it for exactly one thing.
+- `npm run build:site` wires `content-build site`, which nothing here invoked
+  before. It emits one file, `site/content/_index.md`, and that tree is a build
+  artifact and gitignored. `site.out` is required rather than defaulted: the
+  output directory is wiped on every run, and an unset value would resolve to
+  the repository root, so the build refuses it.

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ assets/content/.obsidian/
 /coverage/
 /css/
 
+# The package homepage, emitted by `npm run build:site` from the note in
+# assets/content/. Build output, and the directory is wiped on every run.
+/site/content/
+
 # Cypress run artifacts (specs/support/config are committed)
 /cypress/videos/
 /cypress/screenshots/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ Attribution** check fails any pull request carrying it.
 ## Working on the compendium packs
 
 The packs are **committed JSON**, one file per document, under
-`assets/packs/<name>/`. There is no Markdown content tree in this repository.
+`assets/packs/<name>/`. No compendium document in this repository is compiled
+from Markdown — `assets/content/` holds one note, and it is not a pack document
+(see [The package homepage](#the-package-homepage)).
 
 The comfortable loop is to edit inside Foundry and extract the result:
 
@@ -72,6 +74,26 @@ which is not tracked. Only the JSON under `assets/packs/<name>/` belongs in
 git. `npm run lint:packs` enforces this and CI runs it, so a pull request adding
 `.ldb` files fails — if you find yourself wanting to commit them, the build step
 you are looking for is `npm run build:local`.
+
+## The package homepage
+
+`hm3` publishes one web page, at `https://www.heroiclands.org/hm3/`, and that
+page is `assets/content/Homepage.md` — a `type: homepage` note, whose whole
+frontmatter envelope is `type` and an optional `title`. It compiles to a page
+rather than to a compendium document, so it appears in no pack.
+
+```bash
+npm run build:site       # emits site/content/_index.md, and nothing else
+```
+
+It is **authored, not generated**: everything on it is a person's choice, so
+keep it accurate against `README.md` and the manifest rather than letting it
+drift into claims the system does not make. `site/content/` is a build artifact
+— wiped on every run, and gitignored.
+
+The repository publishes in `homepage` mode (`publish.site` in
+`package-build.config.yaml`), which fences the content surfaces off entirely:
+the tree is never walked for anything but the homepage.
 
 ## Running the system locally
 

--- a/assets/content/Homepage.md
+++ b/assets/content/Homepage.md
@@ -1,0 +1,43 @@
+---
+type: homepage
+title: HârnMaster 3 for Foundry VTT
+---
+
+A game system definition of the HârnMaster 3 RPG for
+[Foundry Virtual Tabletop](http://foundryvtt.com/).
+
+It provides Character, Creature and Container sheets; tracks abilities, skills,
+esoteric talents, injuries and gear; calculates skill bases, penalties,
+endurance and move; rolls skills, spells, ritual invocations, psionics, attacks,
+defences, damage and injury; and runs an automated combat system. Active effects
+supply buffs and debuffs, and macros extend it with your own behaviour.
+
+## Install
+
+In Foundry, add this manifest URL under **Game Systems → Install System**:
+
+```text
+https://github.com/HeroicLands/HarnMaster-3-FoundryVTT/releases/latest/download/system.json
+```
+
+It requires **Foundry VTT 14** or later.
+
+## You still need the rules
+
+This system is not a character generator, and it deliberately ships no skill or
+rules descriptions. Playing with it requires your own copy of the HârnMaster
+rules.
+
+## Source and licence
+
+The source is at
+[HeroicLands/HarnMaster-3-FoundryVTT](https://github.com/HeroicLands/HarnMaster-3-FoundryVTT),
+where bugs and requests are also tracked. The code is licensed under the
+[GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.html).
+
+This is an unofficial HârnFanon work, derived from material created by
+N. Robin Crossby and released for free distribution and personal use without the
+permission or endorsement of N. Robin Crossby or his estate. Hârn, HârnMaster
+and HârnWorld are © 1987–2020 N. Robin Crossby and Columbia Games Inc., whose
+works are available from the
+[Columbia Games website](http://columbiagames.com/harn/).

--- a/package-build.config.yaml
+++ b/package-build.config.yaml
@@ -32,6 +32,29 @@ packs:
     - { name: items, label: Items, type: Item }
     - { name: system-help, label: System Help, type: JournalEntry }
 
+# What this package publishes to the web. `homepage` is the default and is what
+# this repository would get with no `publish:` block at all — it is written out
+# because a mode inherited by omission reads, to the next person, as a question
+# nobody asked. It means: publish the authored homepage at `/hm3/` and nothing
+# else. There is no content tree here to publish, and `content` would look for
+# one; the other mode is not a thing this repository could switch to by editing
+# a line.
+#
+# `manifests` and `address` are left at their defaults for the same reason they
+# are absent everywhere else that has no cross-package links: HM3 neither
+# publishes a link manifest nor consumes one.
+publish:
+    site: homepage
+
+# Where the homepage is written. `out` is the only key that means anything in
+# `homepage` mode — the content surfaces are fenced off by the mode itself — but
+# it is required rather than defaulted, deliberately: the directory is wiped on
+# every run, and an unset value would resolve to the repository root, so the
+# build refuses it instead of resolving it. The path matches the sibling
+# convention; the tree is a build artifact and is gitignored.
+site:
+    out: site/content
+
 packageBuild:
     # Everything Foundry loads that is not generated. `css/` is absent on
     # purpose: it is compiled straight into the stage by `build:css`, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "devDependencies": {
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
-                "@heroiclands/package-build": "^4.0.0",
+                "@heroiclands/package-build": "^5.0.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -888,9 +888,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-4.0.0.tgz",
-            "integrity": "sha512-K9T1C6Bx9ljCB8KCWNXqv1zcepEPCuEqYrkiSbPrrJO5Ch5B4C1LCZ6q1jFm5km5KSw8x9kZv8nTokxU9opD/A==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-5.0.0.tgz",
+            "integrity": "sha512-bFZG+VFArQERQTrpXDsSmEpVyAsbhcB5TuHYp+F/OLjKeOpr5FVXXfCCoGzxhN7PS5xY0ReEnLr63K+3+hWdxA==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "build:compiledb": "node utils/compile-packs.mjs",
         "build:unpackdb": "node utils/unpack-packs.mjs",
         "build:system": "package-build manifest",
+        "build:site": "content-build site",
         "build:pack-release": "package-build release",
         "push:dev": "package-build deploy dev",
         "deploy:dev": "run-s build:local push:dev",
@@ -51,7 +52,7 @@
     "devDependencies": {
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
-        "@heroiclands/package-build": "^4.0.0",
+        "@heroiclands/package-build": "^5.0.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
## What

Three changes, one adoption: this repository moves to `@heroiclands/package-build`
`^5.0.0` (5.0.0 on disk), respells `publish.site` for the mode it became, gives the site
build somewhere to write, and authors the homepage the new mode exists to publish.

- **`publish.site: false` → `publish.site: homepage`.** 5.0.0 replaces the boolean with a
  two-value mode and **refuses both booleans rather than mapping them**, naming the mode to
  write. Confirmed here before the edit:

  ```text
  package-build config: `publish.site` is no longer a boolean — write `site: homepage`. …
  ```

- **A `site:` block, with `out: site/content`.** This repository never had one, because it
  published nothing. `homepage` mode still writes a file, and `site.out` is not defaulted:
  an unset one resolves to the repository root, which the build wipes on every run, so
  5.0.0 refuses to continue without it. The path matches the sibling convention
  (`sohl-thalorna` publishes from `site/content`), and the emitted tree is gitignored — it
  is a build artifact, regenerated and wiped every run.

- **`assets/content/homepage.md`.** A `type: homepage` note; `title` is omitted so it
  defaults to `packageBuild.manifest.title` and the package's name is not written twice.
  This is the **first tracked file** `assets/content/` has ever had: the tree held five
  empty directories git cannot record, so a fresh clone had no content tree at all.

## Why

Consumers resolve `^4`, so a major does not arrive by Dependabot: it is adopted
deliberately, one repository at a time.

The homepage is the part that matters, and it is a carve-out decision already made and
written down — the blockquote at the top of `.github/ISSUE_REPORTING.md`, and the
`publish:` comment in `package-build.config.yaml`. This module's **content** is never
published to heroiclands.org: no journal text, no artwork, no item descriptions, no
compiled notes. That is a licensing boundary, not a gap to fill. It was never a rule
against the module being _named_, and 5.0.0 makes the distinction structural rather than
conventional: `homepage` mode **fences the content surfaces off**, so the tree is never
walked for pages and `sections`, `trees`, `landing` and `backfillSections` emit nothing
even if a later edit declares them. The failure mode this closes is silent — a `site:`
block grown one key at a time, shipping licensed content with nobody noticing.

So the page announces and links, and describes nothing: what the module is, that it needs
a world already running a game system, the install manifest URL, the repository, and the
licence and NOTICE. It names no adventure, location or NPC.

`publish.manifests` is untouched and stays `false` in both directions, for an unrelated
reason: a link manifest is the dependency edge that would stop the module being
withdrawable, and a homepage is not — nothing has to resolve through it, so withdrawing
the module costs a page.

## Verification

**The shipped module does not move.** The established method here is to build twice on the
current version first, so the inherently non-deterministic files are identified before
anything is compared. From a clean stage, twice on 4.0.0: **942 staged files, 940
byte-identical**, and the two that differ are the LevelDB `LOG` and `LOG.old`, whose diffs
are wholly timestamps and thread ids.

Against that baseline, 5.0.0: **942 staged files, the same 940 byte-identical, and the same
two `LOG` files** — no other difference. `homepage.md` is not staged into the module, which
is correct: it is not an asset entry, and the only markdown the module ships is `README.md`.

**The site build emits exactly one page:**

```text
wrote 1 homepage(s) + 0 content page(s) + 0 tree page(s) + 0 landing(s) to site/content
```

```text
site/content/_index.md
```

That is the whole tree — one file. Its frontmatter is `type: homepage`, the derived
`package: harnadventures`, and `title: Hârn Adventures` resolved from the manifest.

## One upstream finding

The walker **accepts** a tree whose only member is a homepage — `content-build site`
publishes it and `package compile` is unaffected — but `content-build lint` fails such a
tree with the diagnostic that says the tree is probably missing:

```text
assets/content: error: holds no keyed content, so every rule here is vacuous — check that the content tree is present and that this is its root
```

It reports "1 finding(s) across 1 note(s)", so the walk did find the homepage; it is the
keyed-address rule that cannot see it, because a homepage carries no `shortcode` by design
and `byKey` stays empty. The guard is right in general and wrong for the two packages 5.0.0
made homepage-only. Filed as HeroicLands/package-build#77 rather than worked around here.
It blocks nothing: this repository wires `content-build lint` into no script and no
workflow.

## No changeset

Deliberate, and consistent with this repository's precedent of none for a change that
ships no module difference. A changeset here bumps the **module's** version and cuts a
GitHub Release; the module is byte-identical, so that release would ship a zip identical to
the previous one under a new number, with notes announcing a page no released artifact
contains. The homepage is not part of the module and is not addressed by any module
version — it publishes from the site build, independently of a release. The issue and this
pull request are the record.

## Follow-up, not in scope

Nothing in this repository runs `content-build site`: there is no `build:site` script and
no site workflow, so the page is authored here but published by whatever assembles
heroiclands.org. Wiring that up is a separate decision about publishing topology and wants
its own issue.

Closes #13
