### PR TITLE
Publish the HM3 homepage at /hm3/

### DIFF
--- a/.changeset/publish-the-homepage.md
+++ b/.changeset/publish-the-homepage.md
@@ -1,0 +1,44 @@
+---
+"hm3": patch
+---
+
+Publish the package homepage at `https://www.heroiclands.org/hm3/`.
+
+`package-build` 5.0.0 gave this repository an authored homepage note and a
+`build:site` that compiled it to Markdown. Nothing rendered that Markdown and
+nothing published it, so the page existed and had no address. Four things close
+the gap, and three of them are one file each.
+
+**`@heroiclands/hugo-theme` 0.2.0** carries the landing layout every package
+homepage renders through — hero band, lead, install block, notices — so six
+package landings look like siblings instead of six hand-built pages. It also
+carries the "page not found" template. It arrives through `npm ci`, not a
+submodule.
+
+**`site/hugo.toml`** roots the site at `site/` and publishes into
+`build/site/hm3/`. The deployed tree therefore carries its own path prefix
+physically, which is what lets the router proxy `/hm3/…` straight through
+without rewriting it, and lets the same deployment behave identically at the
+hosting project's own address. `disableKinds` turns off the section, taxonomy,
+term, RSS and sitemap kinds: this package publishes one page, and Hugo would
+otherwise add a taxonomy root and a feed to a site with no terms and nothing to
+syndicate.
+
+**`build:site` renders as well as compiles** — `build:site-content`
+(`content-build site`) then `build:site-html` (Hugo). It stays out of
+`build:noci`, deliberately: the homepage is not part of what Foundry loads, and
+the packaging build must keep producing exactly what it produced before. It
+does — `build/stage` still holds 540 files, 538 of them byte-identical to the
+previous build, the two that differ being the LevelDB `LOG` files, which carry
+wall-clock timestamps and differ between two runs of the _same_ tree.
+`system.json` is byte-identical and the packs compile the same 1,577 items and
+20 system-help journals.
+
+**`.github/workflows/deploy-site.yml` calls the shared workflow** rather than
+carrying a copy of it. `HeroicLands/.github` owns the runner, the completeness
+guard, the hosting project, the custom domain and the upload — identical for
+every package that publishes a subtree of one site, and exactly the parts that
+must not drift. This repository states its hosting project and passes its two
+secrets by name. It passes no page bounds: `publish.site: homepage` fixes the
+count at exactly one, and the shared guard refuses a caller that tries to move
+it.

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,47 @@
+# Build and publish this package's homepage at https://www.heroiclands.org/hm3/
+# (#424).
+#
+# Almost nothing is here, and that is the point. The runner, the completeness
+# guard, the hosting project, the custom domain and the upload are identical for
+# every package that publishes a subtree of heroiclands.org, so they live once in
+# `HeroicLands/.github` and this repository calls them. Two packages carried a
+# hand-written copy of that logic and the copies drifted (HeroicLands/.github#5).
+#
+# What stays this repository's: its build. The shared workflow runs
+# `npm run build:site` and knows nothing about what that script does — here it
+# compiles `assets/content/Homepage.md` with `content-build site` and renders it
+# with Hugo into `build/site/hm3/`.
+#
+# No page bounds are passed. `publish.site: homepage` in
+# `package-build.config.yaml` fixes the count at exactly one, and the shared
+# workflow *fails* if a homepage-mode caller passes `min-pages` or `max-pages`:
+# the bound is a boundary, and a boundary a caller can widen is not one.
+name: Deploy the HM3 site to Cloudflare Pages
+
+on:
+    # Every push to `main` republishes the page. No path filter: a rebuild is
+    # cheap next to how quietly a hand-maintained path list goes stale, and a
+    # push that changes nothing the page serves merely republishes the same
+    # bytes.
+    push:
+        branches: [main]
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    deploy:
+        # The Pages project is named rather than derived: it does not exist yet,
+        # and the shared workflow creates it on the first run. A project cannot
+        # be renamed later without losing its deployment history, so the name is
+        # settled here once.
+        uses: HeroicLands/.github/.github/workflows/deploy-package-site.yml@main
+        with:
+            project: hm3-site
+        # Passed by name, never `secrets: inherit` — inheriting would hand a
+        # workflow in another repository every secret this one holds, for a job
+        # that needs two.
+        secrets:
+            CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+            CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ assets/content/.obsidian/
 # assets/content/. Build output, and the directory is wiped on every run.
 /site/content/
 
+# Hugo's own scratch lock, created in the Hugo root on every render.
+/site/.hugo_build.lock
+
 # Cypress run artifacts (specs/support/config are committed)
 /cypress/videos/
 /cypress/screenshots/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "devDependencies": {
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
+                "@heroiclands/hugo-theme": "^0.2.0",
                 "@heroiclands/package-build": "^5.0.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
@@ -885,6 +886,16 @@
             },
             "engines": {
                 "node": ">17.0.0"
+            }
+        },
+        "node_modules/@heroiclands/hugo-theme": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/hugo-theme/-/hugo-theme-0.2.0.tgz",
+            "integrity": "sha512-M7E/mMgHRqyIJ13fdKMjUoNl5meC139umAzTc14a02ue7wm6As5gT+5UuIjTDGkEQ+Dy4mq3I5dyOASikMFDsQ==",
+            "dev": true,
+            "license": "GPL-3.0-or-later",
+            "engines": {
+                "node": ">=24.0.0"
             }
         },
         "node_modules/@heroiclands/package-build": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
         "build:compiledb": "node utils/compile-packs.mjs",
         "build:unpackdb": "node utils/unpack-packs.mjs",
         "build:system": "package-build manifest",
-        "build:site": "content-build site",
+        "build:site": "run-s build:site-content build:site-html",
+        "build:site-content": "content-build site",
+        "build:site-html": "hugo --source site --minify --gc --cleanDestinationDir",
         "build:pack-release": "package-build release",
         "push:dev": "package-build deploy dev",
         "deploy:dev": "run-s build:local push:dev",
@@ -52,6 +54,7 @@
     "devDependencies": {
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
+        "@heroiclands/hugo-theme": "^0.2.0",
         "@heroiclands/package-build": "^5.0.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,0 +1,134 @@
+# The HârnMaster 3 package homepage — one page, published at /hm3/ (#424).
+#
+# This repository ships a Foundry *system*; the homepage is not part of what
+# Foundry loads. It is a separate, small build: `content-build site` compiles
+# `assets/content/Homepage.md` into `content/` below, and Hugo renders that one
+# note through the shared theme. Nothing here is in `build:noci`, and nothing
+# here reaches `build/stage`.
+#
+# `baseURL` is the one place the page's address is written down.
+baseURL = "https://www.heroiclands.org/hm3/"
+locale = "en-us"
+
+# The homepage note's authored title, matched here so the two do not drift.
+# Deliberately not the manifest's `HarnMaster 3`: the page greets a reader as
+# the game is spelled, not as the package id is.
+title = "HârnMaster 3 for Foundry VTT"
+
+# The output is published *with* its prefix — `build/site/hm3/` — and the deploy
+# uploads `build/site`, whose root is the hosting project's origin. So the
+# deployment is byte-for-byte what www serves, and the routing layer is a
+# path-preserving pass-through rather than a rewriter.
+#
+# Relative to the **Hugo root**, which is this directory, not the repository
+# root.
+publishDir = "../build/site/hm3"
+
+# Brand chrome, the landing layout and the "page not found" page come from the
+# shared theme, so this page reads as one whole with www and the other packages.
+# It arrives through `npm ci`, not a submodule: Hugo looks for
+# `<themesDir>/<theme>`, so the package's scope is the themes directory and its
+# name is the theme name. Also relative to the Hugo root; the lockfile that
+# installed it is one level up.
+themesDir = "../node_modules/@heroiclands"
+theme = "hugo-theme"
+
+# Written by `npm run build:site-content` from `assets/content/`. Build output:
+# the directory is wiped on every run and is gitignored.
+contentDir = "content"
+
+# One page, and the shared deploy workflow enforces exactly that: a
+# homepage-only package that emitted a second page fails its guard rather than
+# publishing it. Hugo would otherwise add a taxonomy root, a term list and an
+# RSS feed to a site with no taxonomy terms and no feed to serve, so the kinds
+# this package does not publish are turned off here rather than discovered in
+# CI. `sitemap` goes too — a one-page sitemap tells a crawler nothing it did not
+# learn from the page.
+disableKinds = ["section", "taxonomy", "term", "RSS", "sitemap"]
+
+[params]
+  description = "A game system definition of the HârnMaster 3 RPG for Foundry Virtual Tabletop."
+  author = "Tom Rodriguez"
+
+  # The theme carries layout, not addresses, so every site-specific URL it
+  # renders is supplied here. The hero banner and the brand logo both resolve
+  # through `partials/cdn-url.html` against this root; with it unset they would
+  # resolve against this site instead, which publishes no images of its own.
+  cdnBaseURL = "https://cdn.heroiclands.org"
+
+  [params.brand]
+    logo       = "images/brand/sohl-icon-white.webp"
+    licenseURL = "https://www.heroiclands.org/license/"
+    discordURL = "https://discord.gg/EwMfkNd3az"
+
+  # The "page not found" page. Its template is the theme's, since every
+  # consumer needs one; the wording and the routes back are ours. This package
+  # publishes a single page, so the only route back inside it is that page —
+  # the rest lead out, to the source and to the wider site.
+  [params.notfound]
+    tagline  = "This package has no page at"
+    sitenoun = "site"
+
+    [[params.notfound.links]]
+      title = "HârnMaster 3 for Foundry VTT"
+      url   = "/"
+      text  = "What the system does, and the manifest URL to install it."
+    [[params.notfound.links]]
+      title = "Heroic Lands"
+      url   = "https://www.heroiclands.org/"
+      text  = "Everything published here, from the top."
+    [[params.notfound.links]]
+      title = "Source and issues"
+      url   = "https://github.com/HeroicLands/HarnMaster-3-FoundryVTT"
+      text  = "The repository, where bugs and requests are tracked."
+
+# The brand nav. Absolute URLs so this header matches the one every other site
+# renders; defined here rather than in the shared theme, which carries no
+# addresses of its own.
+[menu]
+  [[menu.main]]
+    name = "Home"
+    url = "https://www.heroiclands.org/"
+    weight = 1
+  [[menu.main]]
+    name = "Song of Heroic Lands"
+    url = "https://www.heroiclands.org/projects/song-of-heroic-lands/"
+    weight = 2
+    identifier = "sohl"
+  [[menu.main]]
+    name = "Knowledgebase"
+    url = "https://kb.heroiclands.org/"
+    weight = 1
+    parent = "sohl"
+  [[menu.main]]
+    name = "API Documentation"
+    url = "https://api.heroiclands.org/"
+    weight = 2
+    parent = "sohl"
+  [[menu.main]]
+    name = "Thalorna"
+    url = "https://www.heroiclands.org/thalorna/"
+    weight = 3
+  [[menu.main]]
+    name = "HârnMaster 3"
+    url = "https://www.heroiclands.org/hm3/"
+    weight = 4
+  [[menu.main]]
+    name = "Modules"
+    url = "https://www.heroiclands.org/projects/modules/"
+    weight = 5
+  [[menu.main]]
+    name = "License"
+    url = "https://www.heroiclands.org/license/"
+    weight = 6
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+  [markup.highlight]
+    style = "monokai"
+
+# Only the home page is rendered, so it is the only output to declare.
+[outputs]
+  home = ["HTML"]


### PR DESCRIPTION
Publish the package homepage at `https://www.heroiclands.org/hm3/`.

`package-build` 5.0.0 gave this repository an authored homepage note
(`assets/content/Homepage.md`) and a `build:site` that compiled it to Markdown.
Nothing rendered that Markdown and nothing published it, so the page existed and
had no address. Four things close the gap, three of them one file each.

**`@heroiclands/hugo-theme` 0.2.0** carries the landing layout every package
homepage renders through — hero band, lead, install block, notices — so six
package landings look like siblings rather than six hand-built pages. It also
carries the "page not found" template. It arrives through `npm ci`, not a
submodule: Hugo looks for `<themesDir>/<theme>`, so the package's scope is the
themes directory and its name is the theme name.

**`site/hugo.toml`** roots the site at `site/` and publishes into
`build/site/hm3/`. The deployed tree therefore carries its own path prefix
physically, which is what lets the router proxy `/hm3/…` straight through
without rewriting it, and lets the same deployment behave identically at the
hosting project's own address. `disableKinds` turns off the section, taxonomy,
term, RSS and sitemap kinds — this package publishes one page, and Hugo would
otherwise add a taxonomy root and a feed to a site with no terms and nothing to
syndicate, which the shared guard would (correctly) refuse to deploy.

**`build:site` renders as well as compiles** — `build:site-content`
(`content-build site`) then `build:site-html` (Hugo). It stays out of
`build:noci`, deliberately: the homepage is not part of what Foundry loads.

**`.github/workflows/deploy-site.yml` calls the shared workflow** rather than
carrying a copy of it. `HeroicLands/.github` owns the runner, the completeness
guard, the hosting project, the custom domain and the upload — identical for
every package that publishes a subtree of one site, and exactly the parts that
must not drift. This repository states its hosting project and passes its two
secrets by name. It passes no page bounds: `publish.site: homepage` fixes the
count at exactly one, and the shared guard *fails* a homepage-mode caller that
passes `min-pages` or `max-pages`.

**What the site build emits**

```
build/site/hm3/404.html
build/site/hm3/css/sohl-icons.css
build/site/hm3/css/style.css
build/site/hm3/fonts/game-icons-kb.woff2
build/site/hm3/img/banners/takheperu-hieroglyphs.svg
build/site/hm3/img/cartouches/takheperu.svg
build/site/hm3/index.html
```

One `index.html`, a non-empty `404.html`, and the theme's static assets. No
`_headers`: the shared workflow will write the default one
(HeroicLands/.github#7), and it is byte-identical for every package.

**The packaging path is untouched**, which is what this repository actually
ships. Built before and after with the double-build baseline: `build/stage`
holds 540 files both times, 538 byte-identical, and the two that differ are the
LevelDB `LOG` files, which carry wall-clock timestamps and differ between two
runs of the *same* tree. `build/stage/system.json` is byte-identical, the packs
compile the same 1,577 items and 20 system-help journals, and `npm test` is
green (138 tests).

**Two things this cannot do on its own**

- This repository has no `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`. The
  shared workflow builds and verifies, then fails at "Require the deploy
  credentials" rather than reporting success without deploying. Adding the two
  secrets is what turns the first green run into a published page; the Pages
  project and its `hm3.pkg.heroiclands.org` hostname are then created by the
  workflow itself.
- The theme's banner default for a `type: homepage` page is
  `images/banners/homepage.webp`, which the CDN does not carry — so the hero
  band currently resolves a 404. That gap is shared by every homepage-mode
  package and is one upload to `sohl-cdn-assets` (or a theme fallback), not an
  edit here.

Closes #424
