### PR TITLE
fix(devops): read the changesets output v2 actually sets

### DIFF
--- a/.changeset/release-gate-v2-output-name.md
+++ b/.changeset/release-gate-v2-output-name.md
@@ -1,0 +1,32 @@
+---
+"hm3": patch
+---
+
+Read the changesets output that `changesets/action@v2` actually sets, so the
+release gate can evaluate.
+
+`release.yml` pins `changesets/action@v2` but gated on
+`steps.changesets.outputs.hasChangesets` — a **v1** output name. v2 renamed
+every output to kebab-case (`hasChangesets` → `has-changesets`,
+`pullRequestNumber` → `pr-number`, `publishedPackages` → `published-packages`),
+and a v1 name read against a v2 action resolves to the empty string. The gate
+was therefore `'' == 'false'`, which is false on every run: _Decide whether to
+release_ and every step below it were skipped unconditionally, so no release
+could ever be cut — while the job reported green.
+
+**Nothing this system ships changes.** The correction is one expression in one
+workflow, now `steps.changesets.outputs['has-changesets'] == 'false'`, matching
+the four sibling HeroicLands release workflows that already read the v2 name.
+The audit behind it is the whole file: this was the only reference in the
+repository to an output of a third-party action, and the only stale spelling.
+Every other `steps.<id>.outputs.*` reference resolves to `decide`'s own
+`release` and `tag`, written by the inline script one step above.
+
+The tag-existence half of the gate — which is what keeps an ordinary push, or a
+re-run, from cutting the same release twice, and what makes the hand-cut tags up
+to `v1.6.3` safe to inherit — is unchanged and needs no correction. It is
+byte-identical to the guard that has already run in a sibling repository under
+the v1 name, taking both of its branches: cutting three releases, and reporting
+_"Tag v0.8.2 already exists — nothing to release"_ on four subsequent pushes.
+
+Closes #427.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
             # With changesets pending: opens or updates the Version Packages
             # pull request and stops. With none pending — the state right after
-            # that pull request merges — `hasChangesets` is false, which is the
+            # that pull request merges — `has-changesets` is false, which is the
             # signal that a freshly-versioned commit just landed.
             #
             # This package is `private: true`, so `.changeset/config.json`
@@ -94,9 +94,20 @@ jobs:
             # second keeps an ordinary push (or a re-run) from cutting the same
             # release twice, and is what makes the hand-cut tags up to v1.6.3
             # safe to inherit.
+            #
+            # The output is `has-changesets`. changesets/action v2 renamed every
+            # output to kebab-case (`hasChangesets` -> `has-changesets`,
+            # `pullRequestNumber` -> `pr-number`, `publishedPackages` ->
+            # `published-packages`), and reading a v1 name against a v2 action
+            # yields the empty string: `'' == 'false'` is false, so this step
+            # and every release step below it is skipped on every run, forever,
+            # while the job reports green. Read the name the pinned major
+            # actually declares in its own `action.yml`. Bracket notation
+            # keeps the hyphenated name unambiguous and matches the other
+            # HeroicLands release workflows.
             - name: Decide whether to release
               id: decide
-              if: steps.changesets.outputs.hasChangesets == 'false'
+              if: steps.changesets.outputs['has-changesets'] == 'false'
               run: |
                   VERSION=$(node -p "require('./package.json').version")
                   TAG="v$VERSION"


### PR DESCRIPTION
`release.yml` pins `changesets/action@v2` but gated the release on a **v1**
output name, so the gate could never be true and no release could ever be cut —
while the job reported green.

**The defect**

```yaml
- name: Decide whether to release
  id: decide
  if: steps.changesets.outputs.hasChangesets == 'false'
```

v2 renamed every output to kebab-case. Compared from the action's own manifests,
which are the authority:

| `changesets/action@v1` | `changesets/action@v2` |
| --- | --- |
| `hasChangesets` | `has-changesets` |
| `pullRequestNumber` | `pr-number` |
| `publishedPackages` | `published-packages` |
| `published` | `published` (unchanged) |

`v2/dist/index.js` sets it as `setOutput("has-changesets", String(hasChangesets))`,
so the value really is the string `"true"`/`"false"` the gate compares against.
Reading `hasChangesets` from a v2 step resolves to the empty string, the gate is
`'' == 'false'`, and _Decide whether to release_ — with `Build system`,
`Package system`, `Read changelog section` and `Create GitHub Release`, each
gated on `decide`'s output — is skipped unconditionally.

**The audit**

The whole repository, not just the one line the issue names. Every
`steps.<id>.outputs.*` reference in `.github/`:

| Reference | Producer | Verdict |
| --- | --- | --- |
| `steps.changesets.outputs.hasChangesets` | `changesets/action@v2` | **stale v1 name — fixed here** |
| `steps.decide.outputs.release` (×4) | `decide`'s own `$GITHUB_OUTPUT` | correct |
| `steps.decide.outputs.tag` (×2) | `decide`'s own `$GITHUB_OUTPUT` | correct |

That is the complete list. It was the only reference in the repository to an
output of a third-party action, and the only stale spelling; `pr-number` and
`published-packages` are not read anywhere. The v2 **input** names
(`version-script`, `commit-message`, `pr-title`) were already correct.

**Bracket notation**

`steps.changesets.outputs['has-changesets']`, matching the four sibling
HeroicLands release workflows that already read the v2 name. Dot notation with a
hyphen also parses — GitHub documents property dereference as permitting `-`,
and `actionlint` accepts both — but the bracket form is unambiguous and is the
house style here.

**What this does not prove**

The publish half of the pipeline is untested by construction. Demonstrating that
_Decide whether to release_ reaches a non-`skipped` state requires a push to
`main` with no changesets pending, which is exactly the push that cuts a real
tag and a real GitHub Release — so it cannot be rehearsed. This change is
verified statically only: `actionlint .github/workflows/release.yml` is clean
(the one repository finding, `SC2016` in `build.yml:79`, is pre-existing and
untouched), and the output name is checked against v2's `action.yml` and its
shipped `dist`.

**The duplicate-release guard is unchanged, and is not untested**

The second half of the gate — `git ls-remote --exit-code --tags origin
"refs/tags/$TAG"` — is what keeps an ordinary push or a re-run from cutting the
same release twice, and what makes the hand-cut tags up to `v1.6.3` safe to
inherit. It needs no correction, and it is not code that has never run: it is
byte-identical to the guard in `Song-of-Heroic-Lands-FoundryVTT`, which ran it
under the v1 name and took **both** branches — cutting `v0.8.0`, `v0.8.1` and
`v0.8.2`, and logging _"Tag v0.8.2 already exists — nothing to release"_ on four
later pushes. `--exit-code` returns 2 when no ref matches and 0 when one does,
and `refs/tags/<tag>` is anchored at the start of the ref, so the match is exact
rather than a suffix glob. `concurrency: group: release` with
`cancel-in-progress: false` serializes two pushes racing on the same tag.

One residual sharp edge, called out rather than changed: `>/dev/null 2>&1`
inside the `if` conflates "no such tag" (exit 2) with "could not reach the
remote" (exit 128), so a transient network or auth failure would be read as
_untagged_ and the job would proceed to cut a release. Narrow — `origin` is the
checkout's own authenticated remote and `fetch-depth: 0` has already talked to
it two steps earlier — and fixing it here would mean editing a guard that is
demonstrably working, in the same change that repairs the gate above it. Better
as its own issue, in all five repositories that share this workflow, than
smuggled in here.

**First real run — what to watch**

This change alone releases nothing: `.changeset/` still holds twelve entries, so
`has-changesets` stays `true` and the gate correctly stays shut. The first
exercise is the push that merges #413 (`chore(release): version packages`). On
that run, expect _Decide whether to release_ to be **success, not skipped**, its
log to read `Version 2.0.0 is untagged — releasing v2.0.0` (that PR currently
bumps to `2.0.0`; this patch changeset does not move it), and `Create GitHub
Release` to attach `system.zip` and `system.json`. If it is still `skipped`, the
gate is wrong again and nothing has been lost. If it succeeds but `Build system`
or `Package system` fails, that is the release path's first-ever execution
finding a real build problem — the tag will not have been created, so a re-run
after the fix is safe and will take the same `release=true` branch. If a release
is cut for a version that already has a tag, the `ls-remote` guard failed open;
the `2>&1` note above is the first place to look.

**Not done**

No release cut, no tag pushed, no Release created, nothing merged. The same
stale name exists in `harn-ensemble` (their #13) and, harmlessly, in
`package-build` (#84, where it gates only a cosmetic step); both are out of scope
here.

**Recommendation**

Five repositories now carry near-identical copies of this workflow, and this
defect was introduced into all of them by one dependency bump. That is the case
for a reusable workflow in `HeroicLands/.github` — the pattern the repository
already uses for `labels-sync` and `no-attribution` — parameterized on the
package id and the build script, so the next `changesets/action` major is one
edit rather than five silent regressions.

Closes #427
