### PR TITLE
Repoint the README at HeroicLands, and fix its two broken links

### DIFF
--- a/.changeset/readme-addresses.md
+++ b/.changeset/readme-addresses.md
@@ -1,0 +1,46 @@
+---
+"hm3": patch
+---
+
+Fixed: the README addresses this repository by its current name, and its two
+broken links work again.
+
+`README.md` is staged into the system by `packageBuild.assets` and ships inside
+the released `system.zip` — it is installed alongside the code, not merely
+displayed on a GitHub page. So the addresses it carries are ones players read
+after installing, and the manifest's `readme: README.md` names it.
+
+**What was stale.** Six references still said `toastygm/…`, the owner this
+repository had before it moved; `package.json`, the generated `system.json` and
+every release address have said `HeroicLands/…` since the build was modernised.
+GitHub redirects a renamed owner, so most of them still resolved — which is
+precisely why nobody noticed. They are repointed anyway. The redirect survives
+only until someone claims the vacated name, and three of the six are live
+queries: a release badge, an issue-count badge, and a downloads badge, each of
+which would then begin reporting a different repository's numbers without
+anything here failing.
+
+**What was broken.** Two were not merely stale.
+
+The _Downloads@latest_ badge rendered the text `query not supported`, for either
+owner. It was a `shields.io/badge/dynamic/json` badge whose JSONPath filter
+expression — `assets[?(@.name.includes('zip'))].download_count` — shields.io no
+longer accepts. It is now the built-in
+`shields.io/github/downloads/<owner>/<repo>/latest/total` endpoint, which
+renders the count and drops the hand-rolled `api.github.com` request that badge
+was making.
+
+The link offered as the "official documentation" pointed at
+`toastygm.github.io/HarnMaster-3-FoundryVTT`, a GitHub Pages site that no longer
+exists and returns 404 — there is no equivalent under the new owner either. It
+now points at `https://www.heroiclands.org/hm3/`, the homepage this repository
+publishes, and the section that held it is headed _Documentation_ rather than
+_Pages Site_.
+
+The two wiki links and the release badge simply changed owner; both wiki pages
+exist under the new one. Nothing else in the repository named the old owner,
+and the single remaining mention — in the `modernise-the-build` changeset,
+recording that the manifest addresses were repointed — is a true statement about
+the past and is left alone.
+
+Closes #423.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # HarnMaster-3-FoundryVTT
 
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/toastygm/HarnMaster-3-FoundryVTT)  
-![GitHub issues](https://img.shields.io/github/issues-raw/toastygm/HarnMaster-3-FoundryVTT) 
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/HeroicLands/HarnMaster-3-FoundryVTT)  
+![GitHub issues](https://img.shields.io/github/issues-raw/HeroicLands/HarnMaster-3-FoundryVTT) 
 ![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fhm3)
-[![GitHub downloads (latest)](https://img.shields.io/badge/dynamic/json?label=Downloads@latest&query=assets[?(@.name.includes('zip'))].download_count&url=https://api.github.com/repos/toastygm/HarnMaster-3-FoundryVTT/releases/latest&color=green)](https://github.com/toastygm/HarnMaster-3-FoundryVTT/releases/latest)
+[![GitHub downloads (latest)](https://img.shields.io/github/downloads/HeroicLands/HarnMaster-3-FoundryVTT/latest/total?label=Downloads%40latest&color=green)](https://github.com/HeroicLands/HarnMaster-3-FoundryVTT/releases/latest)
 
 This is a game system definition of the H&acirc;rnMaster 3 RPG for [Foundry Virtual Tabletop](http://foundryvtt.com/).
 
-# Pages Site
-If you are looking for the offical documentation, please see the [HarnMaster 3 FoundryVTT System Site](https://toastygm.github.io/HarnMaster-3-FoundryVTT/).
+# Documentation
+If you are looking for the official documentation, please see the [H&acirc;rnMaster 3 for Foundry VTT](https://www.heroiclands.org/hm3/) page.
 
 ### H&acirc;rnMaster Copyright Notice
 
@@ -35,11 +35,11 @@ The following features are included in this system.
 
 # Recommended Modules
 
-There are a number of modules that extend the H&acirc;rnMaster system by providing new functionality or ready-made content for you to use in your campaign.  See the [Modules](https://github.com/toastygm/HarnMaster-3-FoundryVTT/wiki/Modules) page for more information.
+There are a number of modules that extend the H&acirc;rnMaster system by providing new functionality or ready-made content for you to use in your campaign.  See the [Modules](https://github.com/HeroicLands/HarnMaster-3-FoundryVTT/wiki/Modules) page for more information.
 
 # System Walkthrough
 
-See the [Walkthrough](https://github.com/toastygm/HarnMaster-3-FoundryVTT/wiki/FoundryVTT-HarnMaster-Walkthrough) page for a detailed review of the system (with screenshots).
+See the [Walkthrough](https://github.com/HeroicLands/HarnMaster-3-FoundryVTT/wiki/FoundryVTT-HarnMaster-Walkthrough) page for a detailed review of the system (with screenshots).
 
 # Usage
 


### PR DESCRIPTION
`README.md` is staged into the system by `packageBuild.assets` and ships inside
the released `system.zip` — verified by building: `build/stage/README.md` and the
zip both carry it, and the generated manifest names it as `readme: README.md`.
So the addresses in it are ones installed players read, not just the GitHub
landing page.

Six of those addresses still said `toastygm/…`, the owner this repository had
before it moved. `package.json`, the generated `system.json` and every release
address have said `HeroicLands/…` since the build was modernised; the README was
the only file left behind. A grep of the whole repository found no others.

## What was stale but working

GitHub redirects a renamed owner, so four of the six resolved — which is exactly
why they went unnoticed:

| Reference | Before | After |
| --- | --- | --- |
| Release badge | 200 (`release: v1.6.3`) | 200 (`release: v1.6.3`) |
| Issues badge | 200 (`open issues: 19`) | 200 (`open issues: 19`) |
| Wiki → Modules | 301 → `HeroicLands/…` | 200 |
| Wiki → Walkthrough | 301 → `HeroicLands/…` | 200 |

They are repointed anyway. The redirect lasts only until someone claims the
vacated name, and two of them are live queries: at that point the badges would
begin reporting a different repository's numbers, silently, with nothing here
failing.

## What was actually broken

**The Downloads@latest badge rendered the text `query not supported`.** It was a
`shields.io/badge/dynamic/json` badge whose JSONPath filter expression —
`assets[?(@.name.includes('zip'))].download_count` — shields.io no longer
accepts. This had nothing to do with the rename: it failed identically for both
owners. It is now the built-in
`shields.io/github/downloads/<owner>/<repo>/latest/total` endpoint, which renders
`Downloads@latest: 155k` and drops the hand-rolled `api.github.com` request the
old badge was making.

**The "official documentation" link 404'd.** It pointed at
`https://toastygm.github.io/HarnMaster-3-FoundryVTT/`, a GitHub Pages site that
no longer exists — and there is no equivalent under the new owner
(`heroiclands.github.io/HarnMaster-3-FoundryVTT/` is also 404). It now points at
`https://www.heroiclands.org/hm3/`, the homepage this repository publishes, and
the section heading is _Documentation_ rather than _Pages Site_.

Every link in the README now returns 200; each was fetched to confirm it, and
each of the four badges was fetched and its rendered `<title>` checked so none of
them is a `query not supported` or `invalid` image.

## Deliberately left alone

`.changeset/modernise-the-build.md` mentions `toastygm/` once, recording that
that change repointed the manifest addresses. It is a true statement about the
past and describes history rather than addressing the repository, so it stays.

## Should the README ship?

Yes, and it already does — the framing in the issue is right that it ships, but
that is not itself a defect to undo. The manifest declares `readme: README.md`,
a package-relative path, so removing the file would leave the manifest naming
something that is not there; and an installed system keeps its own documentation
next to its code. What shipping changes is the stakes: it is why stale addresses
here reach players rather than only web visitors, which is the argument for
fixing them, not for dropping the file.

## Verification

`npm run build:noci`, `npm run build:pack-release`, `npm test`,
`npm run lint:packs` and `npm run lint:lang` all pass. `build/stage/README.md`
is byte-identical to the source file and contains no `toastygm` reference, as do
the staged `WALKTHROUGH.md` and generated `system.json`.

Closes #423
