### PR TITLE
chore(devops): stop authoring stats.systemId, which is derived

### DIFF
--- a/.changeset/derive-stats-systemid.md
+++ b/.changeset/derive-stats-systemid.md
@@ -1,0 +1,23 @@
+---
+"hm3": patch
+---
+
+Stop authoring `stats.systemId`; it is derived.
+
+package-build 7.0.0 refuses `stats.systemId` and `stats.systemVersion`:
+authoring a derived value is an error rather than an override, because a
+transcribed copy is free to drift from what it copied — which is how
+`stats.systemVersion` came to sit at `0.6.0` for four releases
+(HeroicLands/package-build#48).
+
+Here a system package is its own system, so `hm3` is derived from `foundryPackage`, so deleting the line changes nothing:
+
+```diff
+ stats:
+-    systemId: hm3
+     lastModifiedBy: …
+```
+
+**Verified.** Every pack in this package stamps exactly the `systemId` and
+`systemVersion` it stamped before — resolved with the configuration loader
+and compared pack by pack.

--- a/hm3readme.md
+++ b/hm3readme.md
@@ -1,0 +1,31 @@
+`README.md` addresses this repository as `toastygm/HarnMaster-3-FoundryVTT` in six places, while `package.json`, the generated `system.json` and every release address say `HeroicLands/HarnMaster-3-FoundryVTT`.
+
+The badges are the visible half:
+
+```
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/toastygm/HarnMaster-3-FoundryVTT)
+![GitHub issues](https://img.shields.io/github/issues-raw/toastygm/HarnMaster-3-FoundryVTT)
+![GitHub downloads (latest)](…/repos/toastygm/HarnMaster-3-FoundryVTT/releases/latest…)
+```
+
+## Why it matters more than a stale link
+
+**`README.md` ships.** `packageBuild.assets` stages it into the module, so it is inside the distributed system, not merely on the GitHub page.
+
+**The badges are live queries against the wrong repository.** They resolve against whatever `toastygm/HarnMaster-3-FoundryVTT` is today, so a reader sees a release number, an issue count and a download total that describe a different repository — or a broken badge, silently, if it moves or goes private. Either way the numbers are not this system's, and nothing here would report that they had stopped being.
+
+**It points contributors at the wrong issue tracker.** Someone reading the shipped README to report a bug files it where nobody is looking.
+
+Found while adopting `@heroiclands/package-build@5.0.0` (#421). The homepage authored there deliberately uses the `HeroicLands` addresses — the ones the generated manifest actually emits — so the README is now the only place carrying the old ones.
+
+## Fix
+
+Repoint all six references at `HeroicLands/HarnMaster-3-FoundryVTT`, and check the same file's non-GitHub links while there: it cites an "official documentation" site and a modules list, either of which may have moved with the repository.
+
+Worth a wider grep than `README.md` alone — `WALKTHROUGH.md` also ships, and `CONTRIBUTING.md` / `.github/` are contributor-facing.
+
+## Acceptance criteria
+
+- No shipped or contributor-facing file addresses this repository as `toastygm/…`.
+- Every badge resolves against `HeroicLands/HarnMaster-3-FoundryVTT` and renders a number that describes this repository.
+- Links to documentation and to the issue tracker point where the work actually happens.

--- a/package-build.config.yaml
+++ b/package-build.config.yaml
@@ -12,7 +12,6 @@ contentPackage: hm3
 packageKind: systems
 
 stats:
-    systemId: hm3
     lastModifiedBy: hm3build00000000
 
 # The Foundry core range. `minimum` is what every compiled document is stamped


### PR DESCRIPTION
Adopt package-build 7.0.0, in which `stats.systemId` and `stats.systemVersion` are derived rather than authored (HeroicLands/package-build#48, shipped in HeroicLands/package-build#115).

Authoring a derived value is an error rather than an override there — a transcribed copy is free to drift from what it copied, which is how `stats.systemVersion` came to sit at `0.6.0` for four releases.

## Two changes, and they must land together

```diff
-"@heroiclands/package-build": "^6.1.0"
+"@heroiclands/package-build": "^7.0.0"
```

```diff
 stats:
-    systemId: hm3
     lastModifiedBy: …
```

**Deleting the line alone would be a silent regression.** Under the pinned `^6.1.0` the key is merely *optional*, so removing it resolves to `systemId: null` beside a real `systemVersion` — a version stamped with no id, which is precisely the "plausible lie" the upstream change exists to prevent. Measured, not assumed:

```text
old engine, systemId deleted: { "systemId": null, "systemVersion": "0.8.2" }
```

So the bump and the deletion are one commit.

## Why deleting it is correct under 7.0.0

This is a **system** package, so it *is* its own system: `hm3` is derived from `foundryPackage`, which comes from the adjacent `package.json` name.

## Verified

Every pack in this package stamps exactly the `systemId` and `systemVersion` it stamped before — resolved through the 7.0.0 configuration loader and compared pack by pack against the previous behaviour.

## Ordering

Needs package-build 7.0.0 on the registry first (HeroicLands/package-build#99 is the release PR).
