### PR TITLE
chore(devops): adopt package-build 7.0.0

### DIFF
--- a/.changeset/adopt-package-build-7.md
+++ b/.changeset/adopt-package-build-7.md
@@ -1,0 +1,19 @@
+---
+"hm3": patch
+---
+
+Adopt package-build 7.0.0.
+
+`stats.systemId` was removed from this repository's configuration because
+7.0.0 derives it (HeroicLands/package-build#48) — but the pin was still
+`^6.1.0`, where the key is merely *optional*. Under 6 the deletion resolves
+to `systemId: null` beside a real `systemVersion`: a version stamped with no
+id, silently, which is the "plausible lie" the upstream change exists to
+prevent.
+
+```text
+under ^6.1.0, systemId deleted: { "systemId": null, "systemVersion": "0.8.2" }
+```
+
+Bumping the pin closes the window. Verified: every pack stamps exactly the
+`systemId` and `systemVersion` it stamped before the deletion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.2.0",
-                "@heroiclands/package-build": "^6.1.0",
+                "@heroiclands/package-build": "^7.0.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -457,9 +457,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-6.1.0.tgz",
-            "integrity": "sha512-Ku8Q0zSYlY2DKE7qOdqIizDTeKhoWdKfNdXZSrMUB2BjxQaCItP0r211XcHOE+gFb0QVZO4jusjmFV6WqzWBqQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-7.0.0.tgz",
+            "integrity": "sha512-nz+VEiT7SjnOWOwBfQdxnqe+E9ZWpIBt83o50ZPoVcqUR+gECddu8BlqMVcMspf2gKz+M+3C8zTuWVz4RhvSzA==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {
@@ -469,12 +469,12 @@
                 "classic-level": "^3.0.0",
                 "dotenv": "^17.2.3",
                 "fflate": "^0.8.3",
-                "glob": "^11.0.3",
+                "glob": "^13.0.6",
                 "gray-matter": "^4.0.3",
                 "handlebars": "^4.7.9",
                 "loglevel": "^1.9.2",
                 "loglevel-plugin-prefix": "^0.8.4",
-                "markdown-it": "^14.1.0",
+                "markdown-it": "^15.0.0",
                 "markdownlint-cli2": "^0.23.2",
                 "prettier": "^3.9.6",
                 "ssh2-sftp-client": "^12.1.1",
@@ -491,15 +491,90 @@
                 "node": ">=24.0.0"
             }
         },
-        "node_modules/@isaacs/cliui": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-            "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+        "node_modules/@heroiclands/package-build/node_modules/argparse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.1.tgz",
+            "integrity": "sha512-nM4mHF/KM1v59ZNKX7zfusQz5wUAxR511YG8Vo6TyiV4aqhu++rbJW4v04xsWhpSsHFj66flT8P7znVpyO20xQ==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "PSF-2.0"
+        },
+        "node_modules/@heroiclands/package-build/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
+        },
+        "node_modules/@heroiclands/package-build/node_modules/linkify-it": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+            "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^3.0.0"
+            }
+        },
+        "node_modules/@heroiclands/package-build/node_modules/markdown-it": {
+            "version": "15.0.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.1.tgz",
+            "integrity": "sha512-9/7gE95FNPkfUWrjJIoHZza2iLmuJlPD0UNMxPi7bxUrbCR525YZY0r+zyfes0dZI5ZZ/uNIXUJca0pJvtw41g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^3.0.0",
+                "entities": "^8.0.0",
+                "linkify-it": "^6.0.0",
+                "mdurl": "^2.1.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^3.0.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/@heroiclands/package-build/node_modules/uc.micro": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+            "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
@@ -3404,23 +3479,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/foreground-child": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.6",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3640,25 +3698,18 @@
             }
         },
         "node_modules/glob": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -4690,22 +4741,6 @@
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/jackspeak": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-            "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^9.0.0"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
         },
         "node_modules/jju": {
             "version": "1.4.0",
@@ -6662,13 +6697,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
         },
         "node_modules/package-manager-detector": {
             "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.2.0",
-        "@heroiclands/package-build": "^6.1.0",
+        "@heroiclands/package-build": "^7.0.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Adopt package-build 7.0.0 (published; HeroicLands/package-build#115).

## This repository is currently mis-stamping

`stats.systemId` was deleted from its configuration because 7.0.0 derives it — but the pin is still `^6.1.0`, where the key is merely **optional**. Under 6 the deletion does not error; it resolves to:

```text
{ "systemId": null, "systemVersion": "0.8.2" }
```

A version stamped with **no id**, silently — which is precisely the "plausible lie" the upstream change exists to prevent, and worse than the missing value HeroicLands/package-build#43 fixed.

Bumping the pin closes the window.

## Verified

Every pack stamps exactly the `systemId` and `systemVersion` it stamped before, resolved through the 7.0.0 configuration loader and compared pack by pack.
