### PR TITLE
refactor: write the data model schemas out as literals

### DIFF
--- a/.changeset/literal-data-model-schemas.md
+++ b/.changeset/literal-data-model-schemas.md
@@ -1,0 +1,43 @@
+---
+"hm3": patch
+---
+
+Write the data model schemas out as literals, so they can be read as data.
+
+`package-build schema` publishes a system's `system` field sets by reading
+`defineSchema()` from source — a DataModel's schema is only introspectable
+inside Foundry, so a content build that wants to know what a document will
+actually receive has to read the declaration rather than run it. Foundry
+discards an unknown `system` key at construction and says nothing about it, and
+that check is what catches it.
+
+The reader follows declarations, not calls. Two places here were built by a
+function instead of written out, and each read back as less than it is:
+
+- **`skillBase: skillBaseField()`** recorded `skillBase` with no keys beneath
+  it, while authored content writes `skillBase.value` on 54,744 embedded skills
+  and `skillBase.formula` on psionics. Those correctly authored fields would
+  have been reported as undeclared.
+- **`abilities: new SchemaField(Object.fromEntries(ABILITIES.map(…)))`**
+  recorded `abilities` alone. That is enough to stop `abilities.strength.base`
+  being called undeclared — a declared ancestor covers what lies under it — but
+  it means the schema never described the ability set at all, so a _misspelt_
+  ability could not be caught. Written out, all 27 ability paths are declared,
+  and a name that is not one of the thirteen is a finding rather than a silent
+  discard.
+
+Nothing about the model changes: the same thirteen abilities under the same
+names, and the same three `skillBase` fields. This is what the declaration
+always meant, spelled so that something other than Foundry can read it.
+
+**Why not teach the reader to follow a factory.** It was tried, and it recovers
+the `skillBase` case but not the `abilities` one — no reader recovers keys that
+are computed at runtime. So the schema would still have been silent about the
+ability set, which is the half that matters here: 2,512 notes author fourteen
+ability keys each, and one of them (`end`) corresponds to no field in this
+model at all. Writing the abilities out is what makes that visible.
+
+**Bump**
+
+_Patch._ A refactor with no change to the emitted schema, the stored data, or
+any behaviour. Only the way the declaration is spelled.

--- a/module/data/actor-models.js
+++ b/module/data/actor-models.js
@@ -19,23 +19,6 @@
 const fields = foundry.data.fields;
 
 /**
- * One ability score. Only `base` is stored; `effective` and `modified` are
- * computed every prepare cycle.
- *
- * @returns {foundry.data.fields.SchemaField}
- */
-function abilityField() {
-    return new fields.SchemaField({
-        base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})
-    });
-}
-
-const ABILITIES = [
-    "strength", "stamina", "dexterity", "agility", "intelligence", "aura", "will",
-    "eyesight", "hearing", "smell", "voice", "comeliness", "morality"
-];
-
-/**
  * The `base` Actor template: everything a character and a creature share.
  */
 export class ActorBaseModel extends foundry.abstract.TypeDataModel {
@@ -46,9 +29,31 @@ export class ActorBaseModel extends foundry.abstract.TypeDataModel {
             species: new fields.StringField({required: true, blank: true, initial: ""}),
             fatigue: new fields.NumberField({required: true, nullable: false, initial: 0}),
             sunsign: new fields.StringField({required: true, blank: true, initial: ""}),
-            abilities: new fields.SchemaField(
-                Object.fromEntries(ABILITIES.map(a => [a, abilityField()]))
-            ),
+            // Written out rather than generated from a name list. The schema is
+            // now read as data by `package-build schema`, and a computed key set
+            // reads there as a field with *no* keys beneath it — enough to keep
+            // `abilities.strength.base` from being called undeclared, but never
+            // enough to catch an ability that is merely misspelt. Thirteen lines
+            // buy that check, and the ability list is the kind of thing a reader
+            // should be able to see rather than assemble.
+            //
+            // Only `base` is stored; `effective` and `modified` are computed
+            // every prepare cycle and are deliberately not in the schema.
+            abilities: new fields.SchemaField({
+                strength: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                stamina: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                dexterity: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                agility: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                intelligence: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                aura: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                will: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                eyesight: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                hearing: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                smell: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                voice: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                comeliness: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})}),
+                morality: new fields.SchemaField({base: new fields.NumberField({required: true, nullable: false, integer: false, initial: 0})})
+            }),
             move: new fields.SchemaField({
                 base: new fields.NumberField({required: true, nullable: false, initial: 0})
             }),

--- a/module/data/item-models.js
+++ b/module/data/item-models.js
@@ -27,19 +27,6 @@
 const fields = foundry.data.fields;
 
 /**
- * A skill-base specification: a rolled value plus the formula it came from.
- *
- * @returns {foundry.data.fields.SchemaField}
- */
-function skillBaseField() {
-    return new fields.SchemaField({
-        value: new fields.NumberField({required: true, nullable: false, initial: 0}),
-        formula: new fields.StringField({required: true, blank: true, initial: ""}),
-        isFormulaValid: new fields.BooleanField({initial: true})
-    });
-}
-
-/**
  * The `base` Item template.
  */
 export class ItemBaseModel extends foundry.abstract.TypeDataModel {
@@ -104,7 +91,15 @@ export class SkillModel extends ItemBaseModel {
     static defineSchema() {
         return Object.assign(super.defineSchema(), {
             type: new fields.StringField({required: true, blank: true, initial: "Craft"}),
-            skillBase: skillBaseField(),
+            // A rolled value plus the formula it came from. Written out rather
+            // than shared through a helper: the schema is read as data by
+            // `package-build schema`, which follows the declaration and not a
+            // function call, and content authors `skillBase.value` directly.
+            skillBase: new fields.SchemaField({
+                value: new fields.NumberField({required: true, nullable: false, initial: 0}),
+                formula: new fields.StringField({required: true, blank: true, initial: ""}),
+                isFormulaValid: new fields.BooleanField({initial: true})
+            }),
             masteryLevel: new fields.NumberField({required: true, nullable: false, initial: 0}),
             effectiveMasteryLevel: new fields.NumberField({required: true, nullable: false, initial: 0}),
             ritual: new fields.SchemaField({
@@ -143,7 +138,15 @@ export class PsionicModel extends ItemBaseModel {
     /** @override */
     static defineSchema() {
         return Object.assign(super.defineSchema(), {
-            skillBase: skillBaseField(),
+            // A rolled value plus the formula it came from. Written out rather
+            // than shared through a helper: the schema is read as data by
+            // `package-build schema`, which follows the declaration and not a
+            // function call, and content authors `skillBase.value` directly.
+            skillBase: new fields.SchemaField({
+                value: new fields.NumberField({required: true, nullable: false, initial: 0}),
+                formula: new fields.StringField({required: true, blank: true, initial: ""}),
+                isFormulaValid: new fields.BooleanField({initial: true})
+            }),
             masteryLevel: new fields.NumberField({required: true, nullable: false, initial: 0}),
             effectiveMasteryLevel: new fields.NumberField({required: true, nullable: false, initial: 0}),
             improveFlag: new fields.BooleanField({initial: false}),


### PR DESCRIPTION
Writes two data model schemas out as literals, so `package-build schema` can
read them.

## Why

A DataModel's schema is only introspectable inside Foundry — `defineSchema()`
returns field classes that do not exist in Node — so a content build that wants
to know what a document will actually receive has to read the *declaration*
rather than run it. Foundry discards an unknown `system` key at construction and
says nothing about it, and that comparison
(HeroicLands/package-build#60) is what catches it.

The reader follows declarations, not calls. Two places here were built by a
function, and each read back as less than it is.

## `skillBase`

`skillBase: skillBaseField()` recorded `skillBase` with no keys beneath it,
while authored content writes `skillBase.value` on **54,744** embedded skills
and `skillBase.formula` on psionics. Those correctly authored fields would have
been reported as undeclared — the check calling a real field a defect.

## `abilities`

`new SchemaField(Object.fromEntries(ABILITIES.map(…)))` recorded `abilities`
alone. That is enough to stop `abilities.strength.base` being reported — a
declared ancestor covers what lies under it — but it means the schema never
described the ability set, so a **misspelt** ability could not be caught.

That is not hypothetical. `harn-ensemble`'s 2,512 notes each author fourteen
ability keys, abbreviated:

```text
str sta dex agl int aur wil eye hrg sml voi cml mor end
```

Thirteen map onto this model's names (`str` → `strength`). **`end` maps to
nothing** — there is no `endurance` field. Written out, all 27 ability paths are
declared, and a name that is not one of the thirteen becomes a finding instead
of a silent discard.

## Why not teach the reader to follow a factory

It was tried, and reverted. Following a call recovers the `skillBase` case but
not the `abilities` one, because no reader recovers keys that are computed at
runtime — so the schema would still have said nothing about the ability set,
which is the half that matters here. Inlining fixes both, and leaves the reader
with fifty fewer lines of AST handling that no repository would then exercise.

## Nothing about the model changes

The same thirteen abilities under the same names, and the same three
`skillBase` fields. This is what the declaration always meant, spelled so that
something other than Foundry can read it.

## Verification

- `npx vitest run` — 3 files, **138** tests, all passing
- `node --check` on both files
- No remaining references to `skillBaseField`, `abilityField` or `ABILITIES`
- Extracted schema: `character` and `creature` go from 15 inherited paths to
  **41**, and every one of the 40 distinct `system.*` paths that
  `harn-ensemble` authors is now declared

## Note

`module/data/actor-models.js` is not Prettier-clean on `main`, and this branch
does not change that — reformatting it would bury a 43-line diff in an
unrelated one. Worth a separate pass; `content-build lint` is also already
failing on `main` with `assets/content: holds no keyed content`.
