### PR TITLE
chore: refuse commits on main with pre-commit/pre-merge-commit hooks

### DIFF
--- a/.changeset/protected-branch-commit-hooks.md
+++ b/.changeset/protected-branch-commit-hooks.md
@@ -1,0 +1,8 @@
+---
+---
+
+Git now refuses a commit made while `HEAD` is on `main`. `.githooks/pre-commit`
+and `.githooks/pre-merge-commit` decline it, so the mistake surfaces before the
+commit exists rather than at push time, where the branch protection catches it
+and the commit has to be moved. Repository tooling only — the hooks are in no
+release artifact — so this declares no bump.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+#
+# Refuse to commit on a protected branch. See protected-branch.sh for the rule
+# and its opt-outs; pre-merge-commit is this hook's counterpart for merges.
+#
+# Installed for everyone via the package.json "prepare" script, which points git
+# at this directory (`git config core.hooksPath .githooks`) on `npm install`.
+
+. "$(dirname "$0")/protected-branch.sh"
+
+guard_protected_branch

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+#
+# Refuse to create a *merge* commit on a protected branch — the `git pull` on
+# main case, which pre-commit never sees, because git runs this hook instead of
+# that one for a merge. See protected-branch.sh for the rule and its opt-outs.
+#
+# Installed for everyone via the package.json "prepare" script, which points git
+# at this directory (`git config core.hooksPath .githooks`) on `npm install`.
+
+. "$(dirname "$0")/protected-branch.sh"
+
+guard_protected_branch

--- a/.githooks/protected-branch.sh
+++ b/.githooks/protected-branch.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+#
+# Shared guard: refuse to create a commit while HEAD is on a protected branch.
+#
+# Sourced by the pre-commit and pre-merge-commit hooks, which are two hooks for
+# one rule: git runs pre-merge-commit *instead of* pre-commit when the commit is
+# a merge, so a repository that guards only pre-commit still lets a stray
+# `git pull` on main write a merge commit.
+#
+# Why guard at commit time at all: `main` is protected on GitHub in every
+# HeroicLands repository — changes land by pull request, squash-merged, never by
+# a direct push. That protection fires at *push* time, by which point the commit
+# already exists on the local branch and has to be moved off it. This moves the
+# refusal forward to the point where the fix is still just "branch first".
+#
+# It is an accident guard, not a security control. `git commit --no-verify`
+# bypasses it, and a repository that genuinely wants commits on its default
+# branch opts out with `git config hooks.allowCommitOnMain true`.
+#
+# Known gap: `git cherry-pick` and `git revert` run neither hook, and a rebase
+# replays commits with HEAD detached (deliberately allowed below).
+#
+# This file is copied verbatim into every HeroicLands repository, for the same
+# reason the commit-msg hook is: a hook runs from your checkout, so it cannot be
+# shared through a GitHub Action. Keep the copies identical.
+
+guard_protected_branch() {
+    # Per-repository opt-out.
+    if [ "$(git config --bool hooks.allowCommitOnMain 2>/dev/null)" = "true" ]; then
+        return 0
+    fi
+
+    # Detached HEAD — a rebase, a bisect, or an explicit checkout of a commit.
+    # There is no branch to protect, and refusing here would break `git rebase`.
+    branch="$(git symbolic-ref --quiet --short HEAD)" || return 0
+
+    case "$branch" in
+        main | master) ;;
+        *) return 0 ;;
+    esac
+
+    cat >&2 <<EOF
+$(basename "$0"): refusing to commit on the protected branch '$branch'.
+
+'$branch' is protected on GitHub, so this commit could never be pushed from
+here. Move it onto a branch first — this keeps everything you have staged:
+
+    git switch -c <type>/<issue_#>_<slug>
+
+To commit here anyway just this once, use 'git commit --no-verify'. To opt this
+repository out permanently, 'git config hooks.allowCommitOnMain true'.
+EOF
+    return 1
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,13 @@ Every change lands through a pull request.
 2. **Branch off current `main`**, named `<type>/<issue_#>_<short-kebab-summary>`
    — e.g. `feat/308_automatic-blind-rolls`, `bug/327_active-effects-attack-ml`.
    Issue-free housekeeping is `chore/<slug>`.
+
+   **Git refuses a commit on `main`.** Hooks in `.githooks/` — `pre-commit`
+   and `pre-merge-commit` — decline it, so the mistake surfaces before the
+   commit exists rather than at push time. `npm install` activates them. To
+   commit on `main` anyway, `git commit --no-verify`; to opt this checkout out
+   entirely, `git config hooks.allowCommitOnMain true`.
+
 3. **Make the change**, keeping it small and focused.
 4. **Declare the release.** Add a changeset — `npm run changeset` — saying
    whether this is a `patch`, `minor` or `major` and what changed. Write it for


### PR DESCRIPTION
`main` is protected on GitHub, so a commit made on it could never be pushed. That only becomes apparent at push time, once the commit exists and has to be moved off the branch — an avoidable recovery for a mistake git can simply decline.

Add two hooks to the `.githooks/` directory that already carries `commit-msg`, sharing one `protected-branch.sh` guard. Two hooks rather than one because git runs `pre-merge-commit` _instead of_ `pre-commit` for a merge, so guarding only the latter would still let a stray `git pull` on `main` write a merge commit — the likeliest form of the accident.

The guard is deliberately porous: it is an accident guard, not a control. `git commit --no-verify` bypasses it, `git config hooks.allowCommitOnMain true` opts a checkout out permanently, and a detached HEAD returns early so `git rebase` replaying commits is unaffected. `git cherry-pick` and `git revert` run neither hook and are a known gap, noted in the file.

The three files are **byte-identical in every HeroicLands repository**. Like `commit-msg`, a hook runs from your checkout and so cannot be shared through a GitHub Action; copies are the only option, and the header says to keep them identical. Companion PRs go to `Song-of-Heroic-Lands-FoundryVTT`, `sohl-thalorna`, `sohl-kethira-basic`, `package-build`, `heroiclands-hugo-theme`, `harn-ensemble` and `HarnMaster-3-FoundryVTT`.

**Verified** in a throwaway repository, since a hook cannot be unit-tested from the checkout it guards: commit on `main` refused; `--no-verify` allowed; commit on a branch allowed; `git merge --no-ff` onto `main` refused; `git rebase` unaffected; `hooks.allowCommitOnMain=true` allowed; and the existing `commit-msg` attribution guard still fires. A fresh clone was also checked — the hooks are inert until `npm install` runs `prepare`, which is what activates them.

`chore/*` — no tracking issue, per the contributing guide.
