### PR TITLE
fix(devops): regenerate `schema.json` when versioning, so a release can merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "e2e:sweep": "package-build e2e sweep",
         "container:test": "package-build container test",
         "changeset": "changeset",
-        "changeset:version": "changeset version && npm install --package-lock-only",
+        "changeset:version": "changeset version && package-build schema && npm install --package-lock-only",
         "changeset:check": "changeset status --since=origin/main"
     },
     "devDependencies": {


### PR DESCRIPTION
The same defect the sibling system hit for real
(HeroicLands/Song-of-Heroic-Lands-FoundryVTT#1824), caught here before it blocked a
release.

`schema.json` records the system version it describes:

```json
{ "version": 1, "system": "hm3", "systemVersion": "1.6.3", … }
```

`changeset:version` ran `changeset version && npm install --package-lock-only` — bumping
`package.json` and rewriting the lockfile, leaving the schema artifact naming the
**previous** version. `lint:schema` (`package-build schema --check`) then fails, and it is
`lint`'s first step, so the whole release branch goes red.

**The fix** inserts `package-build schema` between the bump that invalidates the artifact
and the lockfile write:

```
changeset version && package-build schema && npm install --package-lock-only
```

**Why it has not been seen here yet.** No release has been cut since the schema artifact
was introduced, so `package.json` and `schema.json` both read `1.6.3` and the check
passes. **23 changesets are pending** — the next release bumps the version, the artifact
goes stale, and `lint` fails on its first step. In the sibling system that release
happened, and its release pull request could not merge.

**Verified locally:** set `package.json` to `1.6.4` and `npm run lint:schema` fails; run
`npx package-build schema` first and `systemVersion` becomes `1.6.4` and it passes. The
simulated bump was reverted — this pull request changes one line and nothing else.

**Scope.** Only the two *systems* are affected: they publish DataModel field sets, so
they have a `schema.json` and a `lint:schema`. The four content packages
(`sohl-thalorna`, `sohl-kethira-basic`, `harn-adventures`, `harn-ensemble`) have neither
and need no change — checked, rather than assumed.

Closes #450
