### PR TITLE
chore(deps): take package-build 17, and address the homepage note

### DIFF
--- a/assets/content/Homepage.md
+++ b/assets/content/Homepage.md
@@ -1,5 +1,6 @@
 ---
 type: homepage
+shortcode: root
 title: HârnMaster 3 for Foundry VTT
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.2.0",
-                "@heroiclands/package-build": "^9.0.0",
+                "@heroiclands/package-build": "^17.0.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -457,9 +457,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-9.0.0.tgz",
-            "integrity": "sha512-iI2yHEyWaHhGtbcZRBsv3nDvZVhv06himG7R/9WZAp/vCL6r09WlaNHIr1lG2ZgjdtwFT5PTY2UNhxF1ZAzzQA==",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-17.0.0.tgz",
+            "integrity": "sha512-2yea4F/hb3OeFOtRuGJgxDiXR1KlNbA+767f8oTanIbO6VMePE64P2o16fkBrTQUiPu7+nCAmSWbHLWTBwThPA==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.2.0",
-        "@heroiclands/package-build": "^9.0.0",
+        "@heroiclands/package-build": "^17.0.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Eight majors on from `^9.0.0`. The declared range becomes `^17.0.0` and the lockfile resolves it.

**One content change:** since 11.0.0 a `type: homepage` note is an ordinary addressed note — published at `/<package>/homepage-<shortcode>/`, which is where `[[homepage-<shortcode>|Text]]` lands — so it must carry a shortcode like every other note. `assets/content/Homepage.md` gains `shortcode: root`. The linter named the fix itself.

That was the **only** finding the eight majors introduce.

I ran each check in the lint chain **individually** on 9.0.0 and again on 17.0.0, rather than through `npm run lint` — `run-s` stops at the first failure, and `lint:markdown` is red here, so the chain would have hidden every check after it:

| check | on 9.0.0 | on 17.0.0 |
| --- | --- | --- |
| `lint:format` | pass | pass |
| `lint:markdown` | **fail (2)** | **fail (2)** — pre-existing, unchanged |
| `lint:addresses` | pass | pass *(after the homepage fix; this was the one regression)* |
| `lint:content-links` | pass | pass |
| `lint:lang` | pass | pass |
| `lint:packs` | pass | pass |
| `lint:schema` | pass | pass |