### PR TITLE
build: emit the content index on every build, on package-build 17.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.2.0",
-                "@heroiclands/package-build": "^17.0.0",
+                "@heroiclands/package-build": "^17.2.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -457,9 +457,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-17.0.0.tgz",
-            "integrity": "sha512-2yea4F/hb3OeFOtRuGJgxDiXR1KlNbA+767f8oTanIbO6VMePE64P2o16fkBrTQUiPu7+nCAmSWbHLWTBwThPA==",
+            "version": "17.2.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-17.2.0.tgz",
+            "integrity": "sha512-OPr+hXqnaANf7feh8o7+Jm9JZ78hAVEYl2fZVx/prJO8E8Sys9r6Emcw9wPF/NiHRNPUSlKfuJoOny1aK9V0tQ==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "clean": "package-build clean",
         "build": "npm ci && npm run build:noci",
         "build:local": "npm i && npm run build:noci",
-        "build:noci": "run-s build:css build:assets build:compiledb lint:roundtrip build:system",
+        "build:noci": "run-s build:css build:assets build:compiledb build:content-index lint:roundtrip build:system",
         "build:css": "sass --load-path=scss scss/hm3.scss build/stage/css/hm3.css",
         "watch:css": "sass --load-path=scss --watch scss/hm3.scss build/stage/css/hm3.css",
         "build:assets": "package-build assets",
@@ -59,13 +59,14 @@
         "container:test": "package-build container test",
         "changeset": "changeset",
         "changeset:version": "changeset version && package-build schema && npm install --package-lock-only",
-        "changeset:check": "changeset status --since=origin/main"
+        "changeset:check": "changeset status --since=origin/main",
+        "build:content-index": "content-build content-index"
     },
     "devDependencies": {
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.2.0",
-        "@heroiclands/package-build": "^17.0.0",
+        "@heroiclands/package-build": "^17.2.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
`build:noci` gains `build:content-index`, so `build/content-index/hm3.jsonl` is produced whenever the package is built rather than whenever someone remembers to run the command by hand.

**Nothing generated it before** — in this repository or any other. The artifact existed only where a person had run `content-build content-index` themselves, and was as fresh as the last time they did. The editor tooling reads it, and compiled JournalEntry links resolve through it.

It goes into `build:noci` rather than a `build:db`, because there is no `build:db` here — and not inside `build:compiledb`, because that is this repository's own pack script (`utils/compile-packs.mjs`) rather than the shared one. It sits after the compile and before the manifest: the index describes the content, so it belongs with the content passes.

The range moves to `^17.2.0`, the version whose records carry a `foundry` block.

**Verified:** one note today — the homepage — which compiles to no Foundry document and so carries no UUID, exactly as an unaddressed note should. The count grows as content lands.
