### PR TITLE
build: generate the content index before the compile, not after

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "clean": "package-build clean",
         "build": "npm ci && npm run build:noci",
         "build:local": "npm i && npm run build:noci",
-        "build:noci": "run-s build:css build:assets build:compiledb build:content-index lint:roundtrip build:system",
+        "build:noci": "run-s build:css build:content-index build:assets build:compiledb lint:roundtrip build:system",
         "build:css": "sass --load-path=scss scss/hm3.scss build/stage/css/hm3.css",
         "watch:css": "sass --load-path=scss --watch scss/hm3.scss build/stage/css/hm3.css",
         "build:assets": "package-build assets",


### PR DESCRIPTION
The index is a frontmatter walk. It reads nothing the compile produces, so running it afterwards was arbitrary — and it stops being arbitrary the moment anything reads it, because a plan generated after its readers is a stale plan.

**No behaviour changes yet**: nothing consumes the index during a build today. This is the ordering that has to hold before anything can, and it is free to establish now — HeroicLands/package-build#243.
