### PR TITLE
Take package-build 19.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.2.0",
-                "@heroiclands/package-build": "^18.1.1",
+                "@heroiclands/package-build": "^18.2.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -742,9 +742,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "18.1.1",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-18.1.1.tgz",
-            "integrity": "sha512-lHABCXc4AAOTI/5Ch/aNM7MWSKhubXOtmO18UqKiJGelKIhqPz57cUDMgULnbyVYCMmJ9MCVVOqeUhbDFrp5aw==",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-18.2.0.tgz",
+            "integrity": "sha512-uWYVC9pw498Fvm+BaA1T4UT0Ue+/Z/U2VVC/RcemBDTqcma0N4UZXnxZE0NW1HfSXjKfB5KbL+51LNRIrgVnCQ==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.2.0",
-                "@heroiclands/package-build": "^18.0.0",
+                "@heroiclands/package-build": "^18.1.1",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -742,9 +742,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-18.0.0.tgz",
-            "integrity": "sha512-9gQG08jakh/TAel2aEo2S8J9iKVGiOSJbTG5LYietQoceNogFii5gVzQgUGI9v27+Pw4nnvVx9dfzyvFxBIO6Q==",
+            "version": "18.1.1",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-18.1.1.tgz",
+            "integrity": "sha512-lHABCXc4AAOTI/5Ch/aNM7MWSKhubXOtmO18UqKiJGelKIhqPz57cUDMgULnbyVYCMmJ9MCVVOqeUhbDFrp5aw==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.2.0",
-                "@heroiclands/package-build": "^18.2.0",
+                "@heroiclands/package-build": "^19.0.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -742,9 +742,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-18.2.0.tgz",
-            "integrity": "sha512-uWYVC9pw498Fvm+BaA1T4UT0Ue+/Z/U2VVC/RcemBDTqcma0N4UZXnxZE0NW1HfSXjKfB5KbL+51LNRIrgVnCQ==",
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-19.0.0.tgz",
+            "integrity": "sha512-cZQ/bd3W9L7n8RE7CP54Kr1L2VlUd9I7Bbym94x+fDRBEKX+S5tps6Rnb2xK6Vp7TEyImuArNb7kx7Z7f0C2Zw==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.2.0",
-        "@heroiclands/package-build": "^18.0.0",
+        "@heroiclands/package-build": "^18.1.1",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.2.0",
-        "@heroiclands/package-build": "^18.2.0",
+        "@heroiclands/package-build": "^19.0.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.2.0",
-        "@heroiclands/package-build": "^18.1.1",
+        "@heroiclands/package-build": "^18.2.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Moves `@heroiclands/package-build` to 18.1.1.

Both releases correct 18.0.0 rather than adding surface:

| | |
| --- | --- |
| **18.1.0** | Restored the gear-suffixed note types — `armorgear`, `concoctiongear`, `projectilegear` (package-build#318) |
| **18.1.1** | A homepage note is no longer refused for an `id` it does not author (package-build#319) |

The second mattered for every repository: it was an **error**, so it failed `lint:addresses`, and `lint` heads the build chain — failing any pull request against a repo carrying a homepage note, whatever that PR changed.

**Verified:** `npm run build:noci` green on 18.1.1.