### PR TITLE
Take package-build 20.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.1",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.2.0",
-                "@heroiclands/package-build": "^19.0.0",
+                "@heroiclands/package-build": "^20.0.0",
                 "cypress": "^15.21.1",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -742,9 +742,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "19.0.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-19.0.0.tgz",
-            "integrity": "sha512-cZQ/bd3W9L7n8RE7CP54Kr1L2VlUd9I7Bbym94x+fDRBEKX+S5tps6Rnb2xK6Vp7TEyImuArNb7kx7Z7f0C2Zw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-20.0.0.tgz",
+            "integrity": "sha512-SpA5N4RqyXyoU3eCF/ys2/MxbAdc+TtQ7p4w9ziFyZsjiHl+bG6HUQh17JoGCzzXAsNa8BIC0gEQDQ9DicDMjw==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@changesets/cli": "^3.0.1",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.2.0",
-        "@heroiclands/package-build": "^19.0.0",
+        "@heroiclands/package-build": "^20.0.0",
         "cypress": "^15.21.1",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Take package-build 20.0.0

The major is an address-grammar change, and all four of its retirements
are refused rather than ignored — a tree that has not swept goes red on
adoption by design. An omitted address segment now defaults from where
the link is written rather than being wildcarded or searched for
(package-build#336); a shortcode must match `^[a-z0-9]+$` (#340); a
being's `sohl.items` entry names the item it copies with `model:`, an
address, and the top-level `shortcode:` it replaced is refused (#334);
and a map note's retired `image:` is no longer read (#149).

None of the four reaches this tree. Its content is a single note, with no
`sohl.items` entry, no capital in any shortcode and no `image:` key.

Verified rather than assumed — the full local gate is green on 20.0.0:

    npm ci             exit 0  (package-build 20.0.0, resolved from the
                               registry with an integrity hash, no `file:`
                               dependency anywhere in the lockfile)
    npm run build:noci exit 0  (css, content index, assets, packs, pack
                               round-trip, manifest)
    npm test           exit 0  (138 tests, 3 files)

`npm run lint` reports two MD001 heading-increment findings, in README.md
and WALKTHROUGH.md. They are **pre-existing and not from this bump**:
running the shared markdownlint rule set from 19.0.0 and from 20.0.0 over
the same two files produces byte-identical output, so the rules did not
move. CI chains its lint checks individually and runs neither markdown
check, which is why `main` is green with them present. Tracked separately
rather than swept in here, since this PR is a dependency bump.

Manifest and lockfile only.
