### PR TITLE
chore: write the install path with ASCII > rather than an arrow

### DIFF
--- a/assets/content/Homepage.md
+++ b/assets/content/Homepage.md
@@ -15,7 +15,7 @@ supply buffs and debuffs, and macros extend it with your own behaviour.
 
 ## Install
 
-In Foundry, add this manifest URL under **Game Systems → Install System**:
+In Foundry, add this manifest URL under **Game Systems > Install System**:
 
 ```text
 https://github.com/HeroicLands/HarnMaster-3-FoundryVTT/releases/latest/download/system.json


### PR DESCRIPTION
## What

The homepage wrote its Foundry install path with `→` (U+2192). It now uses ASCII `>`. One character for one; nothing else in the diff moves.

## Why

Of eight candidate book faces probed over the whole HeroicLands corpus, four carry that arrow — Charis SIL, Libertinus Serif, EB Garamond and Times New Roman. Georgia, Palatino, Hoefler Text and Iowan Old Style do not.

Typst emits no warning for a missing glyph: a probe page requesting Libertinus silently embedded six fonts, including macOS LastResort, which draws a literal tofu box — and exited `0`. So the arrow would set in an unrelated face with nothing to report it.

ASCII `>` is the ordinary menu-path separator and every face has it.

## Notes

Housekeeping, so `chore/` with no tracking issue, per CONTRIBUTING. Part of the character allowlist specified in HeroicLands/package-build#377, which is **not yet implemented** — nothing enforces this automatically yet.
