### PR TITLE
chore: take package-build 20.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@changesets/cli": "^3.0.2",
                 "@foundryvtt/foundryvtt-cli": "^3.0.4",
                 "@heroiclands/hugo-theme": "^0.4.0",
-                "@heroiclands/package-build": "^20.0.0",
+                "@heroiclands/package-build": "^20.2.1",
                 "cypress": "^16.0.0",
                 "dotenv": "^17.4.2",
                 "npm-run-all": "^4.1.5",
@@ -742,9 +742,9 @@
             }
         },
         "node_modules/@heroiclands/package-build": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-20.0.0.tgz",
-            "integrity": "sha512-SpA5N4RqyXyoU3eCF/ys2/MxbAdc+TtQ7p4w9ziFyZsjiHl+bG6HUQh17JoGCzzXAsNa8BIC0gEQDQ9DicDMjw==",
+            "version": "20.2.1",
+            "resolved": "https://registry.npmjs.org/@heroiclands/package-build/-/package-build-20.2.1.tgz",
+            "integrity": "sha512-190x+gzZzkdbWwZtd/Ug01ICPJbTXXkOAigatPq0slT3Ai4mWm/leJHT6SROTpSJ8Tl/HJkMnfocLnrpmdb7Aw==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@changesets/cli": "^3.0.2",
         "@foundryvtt/foundryvtt-cli": "^3.0.4",
         "@heroiclands/hugo-theme": "^0.4.0",
-        "@heroiclands/package-build": "^20.0.0",
+        "@heroiclands/package-build": "^20.2.1",
         "cypress": "^16.0.0",
         "dotenv": "^17.4.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Takes `@heroiclands/package-build` 20.2.1, from **19**. Housekeeping, so `chore/` with no tracking issue, per CONTRIBUTING — the diff is `package.json` and the lockfile.

This is a **major** move and is expected to surface findings. It is taken deliberately in one step rather than incrementally, so whatever the new rules have to say about this tree is heard at once.

## The breaking change in 20.0.0

An omitted address segment now defaults **from where the link is written**, rather than from the package being addressed (package-build#336). A cross-package reference written as a bare address therefore resolves to *this* package and stops finding its target.

`sohl-thalorna` hit exactly this — 64 unresolvable `parentSkillCode` values, tracked as sohl-thalorna#185. If this tree makes cross-package references by bare address, expect the same, and expect it as lint findings rather than as a silent miscompile.

## What else arrives

- **A character allowlist** (#377), enforced by `content-build lint`: Latin letters and diacritics, Latin Extended Additional, an enumerated typography set, the measure notation the rules tables use — and NFC. The tiers were drawn by probing eight candidate book faces over the corpus, so a book can pick a typeface without discovering at print time that no font carries what the notes are written in.
- **A Font Awesome icon role** (#378): `:icon-star:` renders as the element the sheets already emit, so a note names an interface icon instead of pasting a Unicode lookalike.
- **The release fixes.** Nothing reached the registry between 20.0.0 and 20.2.1 — a `node_modules` symlink had been committed, and the changesets action's `git reset --hard` restored it over the install on every run (#381).

## Expectations

I have not pre-migrated this tree, and CI may well be red. That is the intent: the findings are the point of taking the bump, and they are better read from one honest run than guessed at in advance.
